### PR TITLE
Change Tensorboard logging to native pytorch

### DIFF
--- a/autoPyTorch/components/training/trainer.py
+++ b/autoPyTorch/components/training/trainer.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from torch.autograd import Variable
 from autoPyTorch.utils.configspace_wrapper import ConfigWrapper
+from autoPyTorch.utils.tensorboard_logging import configure_tb_log_dir, get_tb_logger
 
 # from util.transforms import mixup_data, mixup_criterion
 # from checkpoints import save_checkpoint
@@ -211,21 +212,18 @@ class Trainer(object):
 
     # MODIFIED
     def tensorboard_log_step(self, budget, step, log, logdir):
-        import tensorboard_logger as tl
+        configure_tb_log_dir(logdir)
+        writer = get_tb_logger()
         worker_path = 'Train/'
-        try:
-            tl.log_value(worker_path + 'budget', float(budget), int(time.time()))
-        except:
-            tl.configure(logdir)
-            tl.log_value(worker_path + 'budget', float(budget), int(time.time()))
-        tl.log_value(worker_path + 'step', float(step + 1), int(time.time()))
+
+        writer.add_scalar(worker_path + 'budget', float(budget), int(time.time()))
+        writer.add_scalar(worker_path + 'step', float(step + 1), int(time.time()))
         for name, value in log.items():
             if isinstance(value, (list, np.ndarray)):
                 for ind, val in enumerate(value):
-                    tl.log_value(worker_path + name + "_layer_" + str(ind), float(val), int(step+1))
+                    writer.add_scalar(worker_path + name + "_layer_" + str(ind), float(val), int(step+1))
             else:
-                tl.log_value(worker_path + name, float(value), int(step+1))
-
+                writer.add_scalar(worker_path + name, float(value), int(step+1))
 
     @staticmethod
     def count_parameters(model):

--- a/autoPyTorch/core/worker.py
+++ b/autoPyTorch/core/worker.py
@@ -6,6 +6,7 @@ import Pyro4
 from hpbandster.core.worker import Worker
 
 from autoPyTorch.components.training.budget_types import BudgetTypeTime
+from autoPyTorch.utils.tensorboard_logging import get_tb_logger
 
 __author__ = "Max Dippel, Michael Burkart and Matthias Urban"
 __version__ = "0.0.1"
@@ -117,9 +118,9 @@ class AutoNetWorker(Worker):
                                             budget=budget, budget_type=self.budget_type, max_budget=self.max_budget, optimize_start_time=optimize_start_time,
                                             refit=False, rescore=False, hyperparameter_config_id=config_id, dataset_info=self.dataset_info)
         except Exception as e:
-            if 'use_tensorboard_logger' in self.pipeline_config and self.pipeline_config['use_tensorboard_logger']:            
-                import tensorboard_logger as tl
-                tl.log_value('Exceptions/' + str(e), budget, int(time.time()))
+            if 'use_tensorboard_logger' in self.pipeline_config and self.pipeline_config['use_tensorboard_logger']:
+                writer = get_tb_logger()
+                writer.log_value('Exceptions/' + str(e), budget, int(time.time()))
             self.autonet_logger.info(str(e))
             raise e
     

--- a/autoPyTorch/pipeline/nodes/image/multiple_datasets.py
+++ b/autoPyTorch/pipeline/nodes/image/multiple_datasets.py
@@ -15,6 +15,7 @@ from autoPyTorch.pipeline.base.sub_pipeline_node import SubPipelineNode
 
 from autoPyTorch.utils.config.config_option import ConfigOption, to_bool
 from autoPyTorch.utils.config.config_file_parser import ConfigFileParser
+from autoPyTorch.utils.tensorboard_logging import get_tb_logger
 
 class MultipleDatasets(SubPipelineNode):
     
@@ -46,8 +47,8 @@ class MultipleDatasets(SubPipelineNode):
             Y_valid = [None] * n_datasets
         
         if 'use_tensorboard_logger' in pipeline_config and pipeline_config['use_tensorboard_logger']:
-            import tensorboard_logger as tl
-            tl.log_value('Train/datasets', float(n_datasets), int(time.time()))
+            writer = get_tb_logger()
+            writer.add_scalar('Train/datasets', float(n_datasets), int(time.time()))
 
         infos = []
         loss = 0
@@ -95,8 +96,8 @@ class MultipleDatasets(SubPipelineNode):
             losses.append(result['loss'])
         
         if 'use_tensorboard_logger' in pipeline_config and pipeline_config['use_tensorboard_logger']:
-            import tensorboard_logger as tl
-            tl.log_value('Train/datasets', float(n_datasets), int(time.time()))
+            writer = get_tb_logger()
+            writer.add_scalar('Train/datasets', float(n_datasets), int(time.time()))
 
         loss = loss / n_datasets
 

--- a/autoPyTorch/pipeline/nodes/image/optimization_algorithm_no_timelimit.py
+++ b/autoPyTorch/pipeline/nodes/image/optimization_algorithm_no_timelimit.py
@@ -27,12 +27,12 @@ from autoPyTorch.components.training.image.budget_types import BudgetTypeTime, B
 import copy
 
 from autoPyTorch.utils.modify_config_space import remove_constant_hyperparameter
-
+from autoPyTorch.utils.tensorboard_logging import configure_tb_log_dir
 from autoPyTorch.utils.loggers import combined_logger, bohb_logger, tensorboard_logger
 
 import pprint
 
-tensorboard_logger_configured = False
+
 
 class OptimizationAlgorithmNoTimeLimit(SubPipelineNode):
     def __init__(self, optimization_pipeline_nodes):
@@ -96,13 +96,8 @@ class OptimizationAlgorithmNoTimeLimit(SubPipelineNode):
         run_id, task_id = pipeline_config['run_id'], pipeline_config['task_id']
 
 
-        global tensorboard_logger_configured
-        if pipeline_config['use_tensorboard_logger'] and not tensorboard_logger_configured:            
-            import tensorboard_logger as tl
-            directory = os.path.join(pipeline_config['result_logger_dir'], "worker_logs_" + str(task_id))
-            os.makedirs(directory, exist_ok=True)
-            tl.configure(directory, flush_secs=60)
-            tensorboard_logger_configured = True
+        if pipeline_config['use_tensorboard_logger']:
+            configure_tb_log_dir(os.path.join(pipeline_config['result_logger_dir'], "worker_logs_" + str(task_id)))
 
         if (refit is not None):
             return self.run_refit(pipeline_config, refit, constants, X_train, Y_train, X_valid, Y_valid)

--- a/autoPyTorch/pipeline/nodes/image/simple_train_node.py
+++ b/autoPyTorch/pipeline/nodes/image/simple_train_node.py
@@ -24,6 +24,7 @@ from autoPyTorch.components.training.image.base_training import BaseTrainingTech
 from autoPyTorch.components.training.image.trainer import Trainer
 from autoPyTorch.components.training.image.checkpoints.save_load import save_checkpoint, load_checkpoint, get_checkpoint_dir
 from autoPyTorch.components.training.image.checkpoints.load_specific import load_model #, load_optimizer, load_scheduler
+from autoPyTorch.utils.tensorboard_logging import get_tb_logger
 
 torch.backends.cudnn.benchmark = True
 
@@ -174,11 +175,11 @@ class SimpleTrainNode(PipelineNode):
                 break
 
             if tensorboard_logging and time.time() - last_log_time >= pipeline_config['tensorboard_min_log_interval']:
-                import tensorboard_logger as tl
+                writer = get_tb_logger()
                 worker_path = 'Train/'
-                tl.log_value(worker_path + 'budget', float(budget), epoch)
+                writer.add_scalar(worker_path + 'budget', float(budget), epoch)
                 for name, value in log.items():
-                    tl.log_value(worker_path + name, float(value), epoch)
+                    writer.add_scalar(worker_path + name, float(value), epoch)
                 last_log_time = time.time()
             
 
@@ -197,11 +198,11 @@ class SimpleTrainNode(PipelineNode):
             final_log = max(logs, key=lambda x:x[opt_metric_name])
 
         if tensorboard_logging:
-            import tensorboard_logger as tl
+            writer = get_tb_logger()
             worker_path = 'Train/'
-            tl.log_value(worker_path + 'budget', float(budget), epoch)
+            writer.add_scalar(worker_path + 'budget', float(budget), epoch)
             for name, value in final_log.items():
-                tl.log_value(worker_path + name, float(value), epoch)
+                writer.add_scalar(worker_path + name, float(value), epoch)
 
         if trainer.latest_checkpoint:
             final_log['checkpoint'] = trainer.latest_checkpoint

--- a/autoPyTorch/pipeline/nodes/train_node.py
+++ b/autoPyTorch/pipeline/nodes/train_node.py
@@ -152,7 +152,7 @@ class TrainNode(PipelineNode):
 
             if pipeline_config["log_every_n_datapoints"] is None:
                 # Log if not logging every n datapoints
-                logger.info("Train node: Logging at epoch", str(epoch))
+                logger.info("Train node: Logging at epoch %d", epoch)
                 if 'use_tensorboard_logger' in pipeline_config and pipeline_config['use_tensorboard_logger']:
                     self.tensorboard_log(budget=budget, epoch=epoch, log=log, logdir=pipeline_config["result_logger_dir"])
 

--- a/autoPyTorch/pipeline/nodes/train_node.py
+++ b/autoPyTorch/pipeline/nodes/train_node.py
@@ -18,6 +18,7 @@ import ConfigSpace
 import ConfigSpace.hyperparameters as CSH
 from autoPyTorch.utils.configspace_wrapper import ConfigWrapper
 from autoPyTorch.utils.config.config_option import ConfigOption, to_bool
+from autoPyTorch.utils.tensorboard_logging import configure_tb_log_dir, get_tb_logger
 from autoPyTorch.components.training.base_training import BaseTrainingTechnique, BaseBatchLossComputationTechnique
 from autoPyTorch.components.training.trainer import Trainer
 
@@ -265,20 +266,18 @@ class TrainNode(PipelineNode):
         return options
     
     def tensorboard_log(self, budget, epoch, log, logdir):
-        import tensorboard_logger as tl
+        configure_tb_log_dir(logdir)
+        writer = get_tb_logger()
+
         worker_path = 'Train/'
-        try:
-            tl.log_value(worker_path + 'budget', float(budget), int(time.time()))
-        except:
-            tl.configure(logdir)
-            tl.log_value(worker_path + 'budget', float(budget), int(time.time()))
-        tl.log_value(worker_path + 'epoch', float(epoch + 1), int(time.time()))
+        writer.add_scalar(worker_path + 'budget', float(budget), int(time.time()))
+        writer.add_scalar(worker_path + 'epoch', float(epoch + 1), int(time.time()))
         for name, value in log.items():
             if isinstance(value, (list, np.ndarray)):
                 for ind, val in enumerate(value):
-                    tl.log_value(worker_path + name + "_layer_" + str(ind), float(val), int(epoch+1))
+                    writer.add_scalar(worker_path + name + "_layer_" + str(ind), float(val), int(epoch+1))
             else:
-                tl.log_value(worker_path + name, float(value), int(epoch+1))
+                writer.add_scalar(worker_path + name, float(value), int(epoch+1))
 
     def get_model_loss(self, trainer, train_loader):
         

--- a/autoPyTorch/utils/tensorboard_logging.py
+++ b/autoPyTorch/utils/tensorboard_logging.py
@@ -1,0 +1,30 @@
+import logging
+import os
+
+from torch.utils.tensorboard import SummaryWriter
+
+def get_tb_logger():
+    global apt_tensorboard_writer
+    if 'apt_tensorboard_writer' not in globals() or apt_tensorboard_writer is None:
+        raise RuntimeError("Please initialize apt_tensorboard_writer before logging.")
+    return apt_tensorboard_writer
+
+def configure_tb_log_dir(logdir):
+    logger = logging.getLogger('autopytorch.tb_logging')
+    global apt_tensorboard_writer
+
+    if 'apt_tensorboard_writer' not in globals():
+        logger.debug("Initializing global variable apt_tensorboard_writer")
+        apt_tensorboard_writer = None
+
+    # Initialize summary writer if log_dir changed
+    if apt_tensorboard_writer is not None and logdir == apt_tensorboard_writer.log_dir:
+        return
+
+    if  apt_tensorboard_writer is None:
+        logger.debug("No tensorboard summary writer detected.")
+    elif logdir != apt_tensorboard_writer.log_dir:
+        logger.debug("Logdir changed from \"{}\" to \"{}\".".format(apt_tensorboard_writer.log_dir, logdir))
+    logger.debug("Initializing tensorboard logger for directory \"{}\".".format(logdir))
+    os.makedirs(logdir, exist_ok=True)
+    apt_tensorboard_writer = SummaryWriter(log_dir=logdir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,4 @@ hpbandster
 fasteners
 torch
 torchvision
-tensorboard_logger
 openml


### PR DESCRIPTION
@LMZimmer 
Address #37: Change tensorboard logging from the module [tensorboard_logger](https://github.com/TeamHG-Memex/tensorboard_logger) to [native pytorch tb logging](https://pytorch.org/docs/stable/tensorboard.html).
Still a singleton, but at least the path is reconfigurable. This is supposed to enable rerunning configurations for evaluation and save the result in different event-files.
Can also put this into module-structure, but not sure where - is it ok for the pipeline to have members and could a `summary_writer` live there?