### PR TITLE
sort value range sets before adding as hyperparameter

### DIFF
--- a/autoPyTorch/pipeline/nodes/embedding_selector.py
+++ b/autoPyTorch/pipeline/nodes/embedding_selector.py
@@ -73,7 +73,7 @@ class EmbeddingSelector(PipelineNode):
             return cs
 
         possible_embeddings = set(pipeline_config["embeddings"]).intersection(self.embedding_modules.keys())
-        selector = cs.add_hyperparameter(CSH.CategoricalHyperparameter("embedding", possible_embeddings, default_value="none"))
+        selector = cs.add_hyperparameter(CSH.CategoricalHyperparameter("embedding", sorted(possible_embeddings), default_value="none"))
         
         for embedding_name, embedding_type in self.embedding_modules.items():
             if (embedding_name not in possible_embeddings):

--- a/autoPyTorch/pipeline/nodes/image/simple_train_node.py
+++ b/autoPyTorch/pipeline/nodes/image/simple_train_node.py
@@ -274,7 +274,7 @@ class SimpleTrainNode(PipelineNode):
         pipeline_config = self.pipeline.get_pipeline_config(**pipeline_config)
         cs = ConfigSpace.ConfigurationSpace()
 
-        hp_batch_loss_computation = cs.add_hyperparameter(CSH.CategoricalHyperparameter("batch_loss_computation_technique", list(self.batch_loss_computation_techniques.keys())))
+        hp_batch_loss_computation = cs.add_hyperparameter(CSH.CategoricalHyperparameter("batch_loss_computation_technique", sorted(self.batch_loss_computation_techniques.keys())))
 
         for name, technique in self.batch_loss_computation_techniques.items():
             parent = {'parent': hp_batch_loss_computation, 'value': name} if hp_batch_loss_computation is not None else None

--- a/autoPyTorch/pipeline/nodes/imputation.py
+++ b/autoPyTorch/pipeline/nodes/imputation.py
@@ -54,7 +54,7 @@ class Imputation(PipelineNode):
         possible_strategies = set(Imputation.strategies).intersection(pipeline_config['imputation_strategies'])
 
         cs = ConfigSpace.ConfigurationSpace()
-        cs.add_hyperparameter(CSH.CategoricalHyperparameter("strategy", possible_strategies))
+        cs.add_hyperparameter(CSH.CategoricalHyperparameter("strategy", sorted(possible_strategies)))
         self._check_search_space_updates()
         return cs
 
@@ -63,4 +63,3 @@ class Imputation(PipelineNode):
             ConfigOption(name='imputation_strategies', default=Imputation.strategies, type=str, list=True, choices=Imputation.strategies)
         ]
         return options
-        

--- a/autoPyTorch/pipeline/nodes/initialization_selector.py
+++ b/autoPyTorch/pipeline/nodes/initialization_selector.py
@@ -61,7 +61,7 @@ class InitializationSelector(PipelineNode):
 
         # add hyperparameters of initialization method
         possible_initialization_methods = set(pipeline_config["initialization_methods"]).intersection(self.initialization_methods.keys())
-        selector = cs.add_hyperparameter(CSH.CategoricalHyperparameter("initialization_method", possible_initialization_methods))
+        selector = cs.add_hyperparameter(CSH.CategoricalHyperparameter("initialization_method", sorted(possible_initialization_methods)))
 
         for method_name, method_type in self.initialization_methods.items():
             if (method_name not in possible_initialization_methods):

--- a/autoPyTorch/pipeline/nodes/loss_module_selector.py
+++ b/autoPyTorch/pipeline/nodes/loss_module_selector.py
@@ -58,7 +58,7 @@ class LossModuleSelector(PipelineNode):
         cs = ConfigSpace.ConfigurationSpace()
 
         possible_loss_modules = set(pipeline_config["loss_modules"]).intersection(self.loss_modules.keys())
-        cs.add_hyperparameter(CSH.CategoricalHyperparameter('loss_module', list(possible_loss_modules)))
+        cs.add_hyperparameter(CSH.CategoricalHyperparameter('loss_module', sorted(possible_loss_modules)))
         self._check_search_space_updates(self.loss_modules.keys(), "*")
         return cs
         

--- a/autoPyTorch/pipeline/nodes/lr_scheduler_selector.py
+++ b/autoPyTorch/pipeline/nodes/lr_scheduler_selector.py
@@ -49,7 +49,7 @@ class LearningrateSchedulerSelector(PipelineNode):
         cs = ConfigSpace.ConfigurationSpace()
 
         possible_lr_scheduler = set(pipeline_config["lr_scheduler"]).intersection(self.lr_scheduler.keys())
-        selector = cs.add_hyperparameter(CSH.CategoricalHyperparameter("lr_scheduler", possible_lr_scheduler))
+        selector = cs.add_hyperparameter(CSH.CategoricalHyperparameter("lr_scheduler", sorted(possible_lr_scheduler)))
         
         for lr_scheduler_name, lr_scheduler_type in self.lr_scheduler.items():
             if (lr_scheduler_name not in possible_lr_scheduler):

--- a/autoPyTorch/pipeline/nodes/network_selector.py
+++ b/autoPyTorch/pipeline/nodes/network_selector.py
@@ -76,7 +76,7 @@ class NetworkSelector(PipelineNode):
         cs = ConfigSpace.ConfigurationSpace()
 
         possible_networks = set(pipeline_config["networks"]).intersection(self.networks.keys())
-        selector = cs.add_hyperparameter(CSH.CategoricalHyperparameter("network", possible_networks))
+        selector = cs.add_hyperparameter(CSH.CategoricalHyperparameter("network", sorted(possible_networks)))
         
         network_list = list()
         for network_name, network_type in self.networks.items():

--- a/autoPyTorch/pipeline/nodes/normalization_strategy_selector.py
+++ b/autoPyTorch/pipeline/nodes/normalization_strategy_selector.py
@@ -72,7 +72,7 @@ class NormalizationStrategySelector(PipelineNode):
         cs = ConfigSpace.ConfigurationSpace()
 
         possible_normalization_strategies = set(pipeline_config["normalization_strategies"]).intersection(self.normalization_strategies.keys())
-        cs.add_hyperparameter(CSH.CategoricalHyperparameter("normalization_strategy", possible_normalization_strategies))
+        cs.add_hyperparameter(CSH.CategoricalHyperparameter("normalization_strategy", sorted(possible_normalization_strategies)))
 
         self._check_search_space_updates()
         return cs

--- a/autoPyTorch/pipeline/nodes/optimizer_selector.py
+++ b/autoPyTorch/pipeline/nodes/optimizer_selector.py
@@ -40,7 +40,7 @@ class OptimizerSelector(PipelineNode):
         cs = ConfigSpace.ConfigurationSpace()
 
         possible_optimizer = set(pipeline_config["optimizer"]).intersection(self.optimizer.keys())
-        selector = cs.add_hyperparameter(CSH.CategoricalHyperparameter("optimizer", possible_optimizer))
+        selector = cs.add_hyperparameter(CSH.CategoricalHyperparameter("optimizer", sorted(possible_optimizer)))
         
         for optimizer_name, optimizer_type in self.optimizer.items():
             if (optimizer_name not in possible_optimizer):

--- a/autoPyTorch/pipeline/nodes/preprocessor_selector.py
+++ b/autoPyTorch/pipeline/nodes/preprocessor_selector.py
@@ -53,7 +53,7 @@ class PreprocessorSelector(PipelineNode):
         cs = ConfigSpace.ConfigurationSpace()
 
         possible_preprocessors = set(pipeline_config["preprocessors"]).intersection(self.preprocessors.keys())
-        selector = cs.add_hyperparameter(CSH.CategoricalHyperparameter("preprocessor", possible_preprocessors))
+        selector = cs.add_hyperparameter(CSH.CategoricalHyperparameter("preprocessor", sorted(possible_preprocessors)))
         
         for preprocessor_name, preprocessor_type in self.preprocessors.items():
             if (preprocessor_name not in possible_preprocessors):

--- a/autoPyTorch/pipeline/nodes/resampling_strategy_selector.py
+++ b/autoPyTorch/pipeline/nodes/resampling_strategy_selector.py
@@ -128,9 +128,9 @@ class ResamplingStrategySelector(PipelineNode):
         possible_over_sampling_methods = set(pipeline_config["over_sampling_methods"]).intersection(self.over_sampling_methods.keys())
         possible_under_sampling_methods = set(pipeline_config["under_sampling_methods"]).intersection(self.under_sampling_methods.keys())
         possible_target_size_strategies = set(pipeline_config["target_size_strategies"]).intersection(self.target_size_strategies.keys())
-        selector_over_sampling = cs.add_hyperparameter(CSH.CategoricalHyperparameter("over_sampling_method", possible_over_sampling_methods))
-        selector_under_sampling = cs.add_hyperparameter(CSH.CategoricalHyperparameter("under_sampling_method", possible_under_sampling_methods))
-        cs.add_hyperparameter(CSH.CategoricalHyperparameter("target_size_strategy", possible_target_size_strategies))
+        selector_over_sampling = cs.add_hyperparameter(CSH.CategoricalHyperparameter("over_sampling_method", sorted(possible_over_sampling_methods)))
+        selector_under_sampling = cs.add_hyperparameter(CSH.CategoricalHyperparameter("under_sampling_method", sorted(possible_under_sampling_methods)))
+        cs.add_hyperparameter(CSH.CategoricalHyperparameter("target_size_strategy", sorted(possible_target_size_strategies)))
 
         for method_name, method_type in self.over_sampling_methods.items():
             if method_name not in possible_over_sampling_methods:

--- a/autoPyTorch/pipeline/nodes/train_node.py
+++ b/autoPyTorch/pipeline/nodes/train_node.py
@@ -177,7 +177,7 @@ class TrainNode(PipelineNode):
         cs = ConfigSpace.ConfigurationSpace()
 
         possible_techniques = set(pipeline_config['batch_loss_computation_techniques']).intersection(self.batch_loss_computation_techniques.keys())
-        hp_batch_loss_computation = CSH.CategoricalHyperparameter("batch_loss_computation_technique", possible_techniques)
+        hp_batch_loss_computation = CSH.CategoricalHyperparameter("batch_loss_computation_technique", sorted(possible_techniques))
         cs.add_hyperparameter(hp_batch_loss_computation)
 
         for name, technique in self.batch_loss_computation_techniques.items():


### PR DESCRIPTION
Hey,

runs were not fully reproducible even if seeds had been set. The reason was that sets were given as categorical hyperparameters instead of lists.