### PR TITLE
Reduce Deadlock Probability

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Run tests
       run: |
         if [ ${{ matrix.code-cov }} ]; then codecov='--cov=autoPyTorch --cov-report=xml'; fi
-        python -m pytest --durations=20 --timeout=500 --timeout-method=thread -v $codecov test
+        python -m pytest --durations=20 --timeout=300 --timeout-method=thread -v $codecov test
     - name: Check for files left behind by test
       if: ${{ always() }}
       run: |

--- a/autoPyTorch/api/base_task.py
+++ b/autoPyTorch/api/base_task.py
@@ -1,5 +1,4 @@
 import copy
-import io
 import json
 import logging.handlers
 import math
@@ -187,6 +186,8 @@ class BaseTask:
         self.resampling_strategy_args = resampling_strategy_args
 
         self.stop_logging_server = None  # type: Optional[multiprocessing.synchronize.Event]
+
+        self._dask_client = None
 
         self.search_space_updates = search_space_updates
         if search_space_updates is not None:
@@ -552,8 +553,11 @@ class BaseTask:
 
     def _do_traditional_prediction(self, num_run: int, time_for_traditional: int) -> int:
 
+        # Mypy Checkings -- Traditional prediction is only called for search
+        # where the following objects are created
         assert self._metric is not None
         assert self._logger is not None
+        assert self._dask_client is not None
 
         self._logger.info("Starting to create dummy predictions.")
 
@@ -742,7 +746,14 @@ class BaseTask:
         if self.task_type is None:
             raise ValueError("Cannot interpret task type from the dataset")
 
-        self._create_dask_client()
+        # If no dask client was provided, we create one, so that we can
+        # start a ensemble process in parallel to smbo optimize
+        if (
+            self._dask_client is None and (self.ensemble_size > 0 or self.n_jobs is not None and self.n_jobs > 1)
+        ):
+            self._create_dask_client()
+        else:
+            self._is_dask_client_internally_created = False
 
         # ============> Run dummy predictions
         num_run = 1
@@ -859,18 +870,20 @@ class BaseTask:
         if proc_ensemble is not None:
             self.ensemble_performance_history = list(proc_ensemble.history)
 
+            if len(proc_ensemble.futures) > 0:
+                # Also add ensemble runs that did not finish within smac time
+                # and add them into the ensemble history
+                self._logger.info("Ensemble script still running, waiting for it to finish.")
+                result = proc_ensemble.futures.pop().result()
+                if result:
+                    ensemble_history, _, _, _ = result
+                    self.ensemble_performance_history.extend(ensemble_history)
+                self._logger.info("Ensemble script finished, continue shutdown.")
+
             # save the ensemble performance history file
             if len(self.ensemble_performance_history) > 0:
                 pd.DataFrame(self.ensemble_performance_history).to_json(
                     os.path.join(self._backend.internals_directory, 'ensemble_history.json'))
-
-            if len(proc_ensemble.futures) > 0:
-                future = proc_ensemble.futures.pop()
-                # Now we need to wait for the future to return as it cannot be cancelled while it
-                # is running: https://stackoverflow.com/a/49203129
-                self._logger.info("Ensemble script still running, waiting for it to finish.")
-                future.result()
-                self._logger.info("Ensemble script finished, continue shutdown.")
 
         self._logger.info("Closing the dask infrastructure")
         self._close_dask_client()
@@ -1132,21 +1145,18 @@ class BaseTask:
     def get_models_with_weights(self) -> List:
         if self.models_ is None or len(self.models_) == 0 or \
                 self.ensemble_ is None:
-            self._load_models(self.resampling_strategy)
+            self._load_models()
 
         assert self.ensemble_ is not None
         return self.ensemble_.get_models_with_weights(self.models_)
 
     def show_models(self) -> str:
-        models_with_weights = self.get_models_with_weights()
-
-        with io.StringIO() as sio:
-            sio.write("[")
-            for weight, model in models_with_weights:
-                sio.write("Weight:%f:\nPipeline:%s)\n" % (weight, model))
-            sio.write("]")
-
-            return sio.getvalue()
+        df = []
+        for weight, model in self.get_models_with_weights():
+            representation = model.get_pipeline_representation()
+            representation.update({'Weight': weight})
+            df.append(representation)
+        return pd.DataFrame(df).to_markdown()
 
     def _print_debug_info_to_log(self) -> None:
         """

--- a/autoPyTorch/configs/default_pipeline_options.json
+++ b/autoPyTorch/configs/default_pipeline_options.json
@@ -6,7 +6,7 @@
             "runtime": 3600,
             "torch_num_threads": 1,
             "early_stopping": 20,
-            "use_tensorboard_logger": "True",
+            "use_tensorboard_logger": "False",
             "use_pynisher": "False",
             "metrics_during_training": "True"
 }

--- a/autoPyTorch/ensemble/abstract_ensemble.py
+++ b/autoPyTorch/ensemble/abstract_ensemble.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
 
@@ -49,7 +49,7 @@ class AbstractEnsemble(object):
         self
 
     @abstractmethod
-    def get_models_with_weights(self, models: BasePipeline) -> List[Tuple[float, BasePipeline]]:
+    def get_models_with_weights(self, models: Dict[Any, BasePipeline]) -> List[Tuple[float, BasePipeline]]:
         """Return a list of (weight, model) pairs
 
         Args:

--- a/autoPyTorch/ensemble/ensemble_selection.py
+++ b/autoPyTorch/ensemble/ensemble_selection.py
@@ -189,7 +189,7 @@ class EnsembleSelection(AbstractEnsemble):
 
     def get_models_with_weights(
         self,
-        models: BasePipeline
+        models: Dict[Any, BasePipeline]
     ) -> List[Tuple[float, BasePipeline]]:
         output = []
         for i, weight in enumerate(self.weights_):

--- a/autoPyTorch/ensemble/singlebest_ensemble.py
+++ b/autoPyTorch/ensemble/singlebest_ensemble.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
 
@@ -97,7 +97,7 @@ class SingleBest(AbstractEnsemble):
                           enumerate(self.identifiers_)
                           if self.weights_[idx] > 0]))
 
-    def get_models_with_weights(self, models: BasePipeline
+    def get_models_with_weights(self, models: Dict[Any, BasePipeline]
                                 ) -> List[Tuple[float, BasePipeline]]:
         output = []
         for i, weight in enumerate(self.weights_):

--- a/autoPyTorch/evaluation/abstract_evaluator.py
+++ b/autoPyTorch/evaluation/abstract_evaluator.py
@@ -58,6 +58,10 @@ class MyTraditionalTabularClassificationPipeline(BaseEstimator):
                  dataset_properties: Dict[str, Any],
                  random_state: Optional[Union[int, np.random.RandomState]] = None,
                  init_params: Optional[Dict] = None):
+        self.config = config
+        self.dataset_properties = dataset_properties
+        self.random_state = random_state
+        self.init_params = init_params
         self.pipeline = autoPyTorch.pipeline.traditional_tabular_classification.\
             TraditionalTabularClassificationPipeline(dataset_properties=dataset_properties)
         configuration_space = self.pipeline.get_hyperparameter_search_space()
@@ -83,6 +87,9 @@ class MyTraditionalTabularClassificationPipeline(BaseEstimator):
 
     def get_additional_run_info(self) -> None:  # pylint: disable=R0201
         return None
+
+    def get_pipeline_representation(self) -> Dict[str, str]:
+        return self.pipeline.get_pipeline_representation()
 
     @staticmethod
     def get_default_pipeline_options() -> Dict[str, Any]:

--- a/autoPyTorch/optimizer/smbo.py
+++ b/autoPyTorch/optimizer/smbo.py
@@ -246,7 +246,6 @@ class AutoMLSMBO(object):
             backend=copy.deepcopy(self.backend),
             seed=seed,
             initial_num_run=num_run,
-            logger=self.logger,
             include=self.include if self.include is not None else dict(),
             exclude=self.exclude if self.exclude is not None else dict(),
             metric=self.metric,

--- a/autoPyTorch/optimizer/smbo.py
+++ b/autoPyTorch/optimizer/smbo.py
@@ -328,9 +328,11 @@ class AutoMLSMBO(object):
         if self.ensemble_callback is not None:
             smac.register_callback(self.ensemble_callback)
 
-        self.logger.info("initialised smac, running optimise")
+        self.logger.info("initialised SMBO, running SMBO.optimize()")
 
         smac.optimize()
+
+        self.logger.info("finished SMBO.optimize()")
 
         self.runhistory = smac.solver.runhistory
         self.trajectory = smac.solver.intensifier.traj_logger.trajectory

--- a/autoPyTorch/pipeline/base_pipeline.py
+++ b/autoPyTorch/pipeline/base_pipeline.py
@@ -522,6 +522,19 @@ class BasePipeline(Pipeline):
         """
         return self._additional_run_info
 
+    def get_pipeline_representation(self) -> Dict[str, str]:
+        """
+        Returns a representation of the pipeline, so that it can be
+        consumed and formatted by the API.
+
+        It should be a representation that follows:
+        [{'PreProcessing': <>, 'Estimator': <>}]
+
+        Returns:
+            Dict: contains the pipeline representation in a short format
+        """
+        raise NotImplementedError()
+
     @staticmethod
     def get_default_pipeline_options() -> Dict[str, Any]:
         return {

--- a/autoPyTorch/pipeline/components/setup/network/base_network.py
+++ b/autoPyTorch/pipeline/components/setup/network/base_network.py
@@ -131,6 +131,13 @@ class NetworkComponent(autoPyTorchTrainingComponent):
         cs = ConfigurationSpace()
         return cs
 
+    @staticmethod
+    def get_properties(dataset_properties: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+        return {
+            'shortname': 'nn.Sequential',
+            'name': 'torch.nn.Sequential',
+        }
+
     def __str__(self) -> str:
         """ Allow a nice understanding of what components where used """
         string = self.network.__class__.__name__

--- a/autoPyTorch/pipeline/components/setup/traditional_ml/classifier_models/classifiers.py
+++ b/autoPyTorch/pipeline/components/setup/traditional_ml/classifier_models/classifiers.py
@@ -106,6 +106,13 @@ class LGBModel(BaseClassifier):
         y_pred = self.model.predict(X_test)
         return y_pred
 
+    @staticmethod
+    def get_properties(dataset_properties: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+        return {
+            'shortname': 'LGBMClassifier',
+            'name': 'LGBMClassifier',
+        }
+
 
 class CatboostModel(BaseClassifier):
 
@@ -167,6 +174,13 @@ class CatboostModel(BaseClassifier):
         y_pred = self.model.predict(X_test)
         return y_pred
 
+    @staticmethod
+    def get_properties(dataset_properties: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+        return {
+            'shortname': 'CatBoostClassifier',
+            'name': 'CatBoostClassifier',
+        }
+
 
 class RFModel(BaseClassifier):
 
@@ -225,6 +239,13 @@ class RFModel(BaseClassifier):
             return self.model.predict_proba(X_test)
         y_pred = self.model.predict(X_test)
         return y_pred
+
+    @staticmethod
+    def get_properties(dataset_properties: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+        return {
+            'shortname': 'RandomForestClassifier',
+            'name': 'RandomForestClassifier',
+        }
 
 
 class ExtraTreesModel(BaseClassifier):
@@ -285,6 +306,13 @@ class ExtraTreesModel(BaseClassifier):
         y_pred = self.model.predict(X_test)
         return y_pred
 
+    @staticmethod
+    def get_properties(dataset_properties: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+        return {
+            'shortname': 'ExtraTreesClassifier',
+            'name': 'ExtraTreesClassifier',
+        }
+
 
 class KNNModel(BaseClassifier):
 
@@ -338,6 +366,13 @@ class KNNModel(BaseClassifier):
         y_pred = self.model.predict(X_test)
         return y_pred
 
+    @staticmethod
+    def get_properties(dataset_properties: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+        return {
+            'shortname': 'KNeighborsClassifier',
+            'name': 'KNeighborsClassifier',
+        }
+
 
 class SVMModel(BaseClassifier):
 
@@ -384,3 +419,10 @@ class SVMModel(BaseClassifier):
             return self.model.predict_proba(X_test)
         y_pred = self.model.predict(X_test)
         return y_pred
+
+    @staticmethod
+    def get_properties(dataset_properties: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+        return {
+            'shortname': 'SVC',
+            'name': 'SVC',
+        }

--- a/autoPyTorch/pipeline/components/setup/traditional_ml/classifier_models/classifiers.py
+++ b/autoPyTorch/pipeline/components/setup/traditional_ml/classifier_models/classifiers.py
@@ -110,7 +110,7 @@ class LGBModel(BaseClassifier):
     def get_properties(dataset_properties: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
         return {
             'shortname': 'LGBMClassifier',
-            'name': 'LGBMClassifier',
+            'name': 'Light Gradient Boosting Machine Classifier',
         }
 
 
@@ -178,7 +178,7 @@ class CatboostModel(BaseClassifier):
     def get_properties(dataset_properties: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
         return {
             'shortname': 'CatBoostClassifier',
-            'name': 'CatBoostClassifier',
+            'name': 'Categorical Boosting Classifier',
         }
 
 
@@ -243,8 +243,8 @@ class RFModel(BaseClassifier):
     @staticmethod
     def get_properties(dataset_properties: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
         return {
-            'shortname': 'RandomForestClassifier',
-            'name': 'RandomForestClassifier',
+            'shortname': 'RFClassifier',
+            'name': 'Random Forest Classifier',
         }
 
 
@@ -369,8 +369,8 @@ class KNNModel(BaseClassifier):
     @staticmethod
     def get_properties(dataset_properties: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
         return {
-            'shortname': 'KNeighborsClassifier',
-            'name': 'KNeighborsClassifier',
+            'shortname': 'KNNClassifier',
+            'name': 'K Nearest Neighbors Classifier',
         }
 
 
@@ -424,5 +424,5 @@ class SVMModel(BaseClassifier):
     def get_properties(dataset_properties: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
         return {
             'shortname': 'SVC',
-            'name': 'SVC',
+            'name': 'Support Vector Classification',
         }

--- a/autoPyTorch/pipeline/components/training/trainer/base_trainer.py
+++ b/autoPyTorch/pipeline/components/training/trainer/base_trainer.py
@@ -255,7 +255,6 @@ class BaseTrainerComponent(autoPyTorchTrainingComponent):
 
         for step, (data, targets) in enumerate(train_loader):
             if self.budget_tracker.is_max_time_reached():
-                logger.info("Stopping training as max time reached")
                 break
 
             loss, outputs = self.train_step(data, targets)

--- a/autoPyTorch/pipeline/components/training/trainer/base_trainer.py
+++ b/autoPyTorch/pipeline/components/training/trainer/base_trainer.py
@@ -15,7 +15,6 @@ from autoPyTorch.constants import REGRESSION_TASKS
 from autoPyTorch.pipeline.components.training.base_training import autoPyTorchTrainingComponent
 from autoPyTorch.pipeline.components.training.metrics.utils import calculate_score
 from autoPyTorch.utils.implementations import get_loss_weight_strategy
-from autoPyTorch.utils.logging_ import PicklableClientLogger
 
 
 class BudgetTracker(object):
@@ -233,7 +232,7 @@ class BaseTrainerComponent(autoPyTorchTrainingComponent):
         return False
 
     def train_epoch(self, train_loader: torch.utils.data.DataLoader, epoch: int,
-                    logger: PicklableClientLogger, writer: Optional[SummaryWriter],
+                    writer: Optional[SummaryWriter],
                     ) -> Tuple[float, Dict[str, float]]:
         '''
             Trains the model for a single epoch.

--- a/autoPyTorch/pipeline/components/training/trainer/base_trainer_choice.py
+++ b/autoPyTorch/pipeline/components/training/trainer/base_trainer_choice.py
@@ -190,9 +190,10 @@ class TrainerChoice(autoPyTorchChoice):
 
         # Setup the logger
         self.logger = get_named_client_logger(
-            name=X['num_run'],
+            name=f"{X['num_run']}_{time.time()}",
             # Log to a user provided port else to the default logging port
-            port=X['logger_port'] if 'logger_port' in X else logging.handlers.DEFAULT_TCP_LOGGING_PORT,
+            port=X['logger_port'
+                   ] if 'logger_port' in X else logging.handlers.DEFAULT_TCP_LOGGING_PORT,
         )
 
         fit_function = self._fit
@@ -294,7 +295,6 @@ class TrainerChoice(autoPyTorchChoice):
             train_loss, train_metrics = self.choice.train_epoch(
                 train_loader=X['train_data_loader'],
                 epoch=epoch,
-                logger=self.logger,
                 writer=writer,
             )
 
@@ -325,13 +325,16 @@ class TrainerChoice(autoPyTorchChoice):
             if self.choice.on_epoch_end(X=X, epoch=epoch):
                 break
 
+            self.logger.debug(self.run_summary.repr_last_epoch())
+
             # Reached max epoch on next iter, don't even go there
             if budget_tracker.is_max_epoch_reached(epoch + 1):
                 break
 
             epoch += 1
 
-            torch.cuda.empty_cache()
+            if 'cuda' in X['device']:
+                torch.cuda.empty_cache()
 
         # wrap up -- add score if not evaluating every epoch
         if not self.eval_valid_each_epoch(X):

--- a/autoPyTorch/pipeline/components/training/trainer/base_trainer_choice.py
+++ b/autoPyTorch/pipeline/components/training/trainer/base_trainer_choice.py
@@ -325,8 +325,6 @@ class TrainerChoice(autoPyTorchChoice):
             if self.choice.on_epoch_end(X=X, epoch=epoch):
                 break
 
-            self.logger.debug(self.run_summary.repr_last_epoch())
-
             # Reached max epoch on next iter, don't even go there
             if budget_tracker.is_max_epoch_reached(epoch + 1):
                 break
@@ -351,7 +349,6 @@ class TrainerChoice(autoPyTorchChoice):
                 val_metrics=val_metrics,
                 test_metrics=test_metrics,
             )
-            self.logger.debug(self.run_summary.repr_last_epoch())
             self.save_model_for_ensemble()
 
         self.logger.info(f"Finished training with {self.run_summary.repr_last_epoch()}")

--- a/autoPyTorch/pipeline/tabular_regression.py
+++ b/autoPyTorch/pipeline/tabular_regression.py
@@ -10,6 +10,7 @@ from sklearn.base import RegressorMixin
 from autoPyTorch.constants import STRING_TO_TASK_TYPES
 from autoPyTorch.pipeline.base_pipeline import BasePipeline
 from autoPyTorch.pipeline.components.base_choice import autoPyTorchChoice
+from autoPyTorch.pipeline.components.base_component import autoPyTorchComponent
 from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.TabularColumnTransformer import (
     TabularColumnTransformer
 )
@@ -171,6 +172,39 @@ class TabularRegressionPipeline(RegressorMixin, BasePipeline):
             ("trainer", TrainerChoice(default_dataset_properties)),
         ])
         return steps
+
+    def get_pipeline_representation(self) -> Dict[str, str]:
+        """
+        Returns a representation of the pipeline, so that it can be
+        consumed and formatted by the API.
+
+        It should be a representation that follows:
+        [{'PreProcessing': <>, 'Estimator': <>}]
+
+        Returns:
+            Dict: contains the pipeline representation in a short format
+        """
+        preprocessing = []
+        estimator = []
+        skip_steps = ['data_loader', 'trainer', 'lr_scheduler', 'optimizer', 'network_init',
+                      'preprocessing', 'tabular_transformer']
+        for step_name, step_component in self.steps:
+            if step_name in skip_steps:
+                continue
+            properties = {}
+            if isinstance(step_component, autoPyTorchChoice) and step_component.choice is not None:
+                properties = step_component.choice.get_properties()
+            elif isinstance(step_component, autoPyTorchComponent):
+                properties = step_component.get_properties()
+            if 'shortname' in properties:
+                if 'network' in step_name:
+                    estimator.append(properties['shortname'])
+                else:
+                    preprocessing.append(properties['shortname'])
+        return {
+            'Preprocessing': ','.join(preprocessing),
+            'Estimator': ','.join(estimator),
+        }
 
     def _get_estimator_hyperparameter_name(self) -> str:
         """

--- a/autoPyTorch/pipeline/traditional_tabular_classification.py
+++ b/autoPyTorch/pipeline/traditional_tabular_classification.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 from ConfigSpace.configuration_space import Configuration, ConfigurationSpace
 
@@ -197,3 +197,23 @@ class TraditionalTabularClassificationPipeline(ClassifierMixin, BasePipeline):
             str: name of the pipeline type
         """
         return "tabular_classifier"
+
+    def get_pipeline_representation(self) -> Dict[str, str]:
+        """
+        Returns a representation of the pipeline, so that it can be
+        consumed and formatted by the API.
+
+        It should be a representation that follows:
+        [{'PreProcessing': <>, 'Estimator': <>}]
+
+        Returns:
+            Dict: contains the pipeline representation in a short format
+        """
+        estimator_name = 'TraditionalTabularClassification'
+        if self.steps[0][1].choice is not None:
+            estimator_name = cast(str,
+                                  self.steps[0][1].choice.model.get_properties()['shortname'])
+        return {
+            'Preprocessing': 'None',
+            'Estimator': estimator_name,
+        }

--- a/examples/example_tabular_classification.py
+++ b/examples/example_tabular_classification.py
@@ -82,3 +82,4 @@ if __name__ == '__main__':
     y_pred = api.predict(X_test)
     score = api.score(y_pred, y_test)
     print(score)
+    print(api.show_models())

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ distributed>=2.2.0
 catboost
 lightgbm
 flaky
+tabulate

--- a/test/test_ensemble/test_ensemble.py
+++ b/test/test_ensemble/test_ensemble.py
@@ -558,15 +558,15 @@ def testLimit(ensemble_backend):
         logger_mock.handlers = []
         get_logger_mock.return_value = logger_mock
 
-        ensbuilder.run(time_left=1000, iteration=0)
+        ensbuilder.run(time_left=1000, iteration=0, pynisher_context='fork')
         assert os.path.exists(read_scores_file)
         assert not os.path.exists(read_preds_file)
         assert logger_mock.warning.call_count == 1
-        ensbuilder.run(time_left=1000, iteration=0)
+        ensbuilder.run(time_left=1000, iteration=0, pynisher_context='fork')
         assert os.path.exists(read_scores_file)
         assert not os.path.exists(read_preds_file)
         assert logger_mock.warning.call_count == 2
-        ensbuilder.run(time_left=1000, iteration=0)
+        ensbuilder.run(time_left=1000, iteration=0, pynisher_context='fork')
         assert os.path.exists(read_scores_file)
         assert not os.path.exists(read_preds_file)
         assert logger_mock.warning.call_count == 3
@@ -574,7 +574,7 @@ def testLimit(ensemble_backend):
         # it should try to reduce ensemble_nbest until it also failed at 2
         assert ensbuilder.ensemble_nbest == 1
 
-        ensbuilder.run(time_left=1000, iteration=0)
+        ensbuilder.run(time_left=1000, iteration=0, pynisher_context='fork')
         assert os.path.exists(read_scores_file)
         assert not os.path.exists(read_preds_file)
         assert logger_mock.warning.call_count == 4
@@ -584,7 +584,7 @@ def testLimit(ensemble_backend):
 
         # And then it still runs, but basically won't do anything any more except for raising error
         # messages via the logger
-        ensbuilder.run(time_left=1000, iteration=0)
+        ensbuilder.run(time_left=1000, iteration=0, pynisher_context='fork')
         assert os.path.exists(read_scores_file)
         assert not os.path.exists(read_preds_file)
         assert logger_mock.warning.call_count == 4
@@ -715,14 +715,14 @@ def test_ensemble_builder_nbest_remembered(fit_ensemble, ensemble_backend, dask_
         max_iterations=None,
     )
 
-    manager.build_ensemble(dask_client)
+    manager.build_ensemble(dask_client, unit_test=True)
     future = manager.futures[0]
     dask.distributed.wait([future])  # wait for the ensemble process to finish
     assert future.result() == ([], 5, None, None)
     file_path = os.path.join(ensemble_backend.internals_directory, 'ensemble_read_preds.pkl')
     assert not os.path.exists(file_path)
 
-    manager.build_ensemble(dask_client)
+    manager.build_ensemble(dask_client, unit_test=True)
 
     future = manager.futures[0]
     dask.distributed.wait([future])  # wait for the ensemble process to finish

--- a/test/test_evaluation/test_evaluation.py
+++ b/test/test_evaluation/test_evaluation.py
@@ -100,7 +100,8 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger_port=self.logger_port
+                                    logger_port=self.logger_port,
+                                    pynisher_context='fork',
                                     )
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
                                       instance_specific=None, seed=1, capped=False))
@@ -119,7 +120,8 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger_port=self.logger_port
+                                    logger_port=self.logger_port,
+                                    pynisher_context='fork',
                                     )
         self.stats.ta_runs = 1
         ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None, instance_specific=None,
@@ -144,7 +146,8 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger_port=self.logger_port
+                                    logger_port=self.logger_port,
+                                    pynisher_context='fork',
                                     )
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
                                       instance_specific=None, seed=1, capped=False))
@@ -163,7 +166,8 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger_port=self.logger_port
+                                    logger_port=self.logger_port,
+                                    pynisher_context='fork',
                                     )
         self.scenario.wallclock_limit = 5
         self.stats.submitted_ta_runs += 1
@@ -183,7 +187,8 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger_port=self.logger_port
+                                    logger_port=self.logger_port,
+                                    pynisher_context='fork',
                                     )
 
         # The following should not fail because abort on first config crashed is false
@@ -223,7 +228,8 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger_port=self.logger_port
+                                    logger_port=self.logger_port,
+                                    pynisher_context='fork',
                                     )
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
                                       instance_specific=None, seed=1, capped=False))
@@ -260,7 +266,8 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger_port=self.logger_port
+                                    logger_port=self.logger_port,
+                                    pynisher_context='fork',
                                     )
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
                                       instance_specific=None, seed=1, capped=False))
@@ -282,7 +289,8 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger_port=self.logger_port
+                                    logger_port=self.logger_port,
+                                    pynisher_context='fork',
                                     )
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
                                       instance_specific=None, seed=1, capped=False))
@@ -308,7 +316,8 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger_port=self.logger_port
+                                    logger_port=self.logger_port,
+                                    pynisher_context='fork',
                                     )
         self.scenario.wallclock_limit = 180
         instance = "{'subsample': 30}"
@@ -331,7 +340,8 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger_port=self.logger_port
+                                    logger_port=self.logger_port,
+                                    pynisher_context='fork',
                                     )
         self.stats.submitted_ta_runs += 1
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
@@ -353,7 +363,8 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger_port=self.logger_port
+                                    logger_port=self.logger_port,
+                                    pynisher_context='fork',
                                     )
         ta.pynisher_logger = unittest.mock.Mock()
         self.stats.submitted_ta_runs += 1

--- a/test/test_evaluation/test_evaluation.py
+++ b/test/test_evaluation/test_evaluation.py
@@ -1,4 +1,4 @@
-import logging
+import logging.handlers
 import os
 import shutil
 import sys
@@ -46,7 +46,7 @@ class EvaluationTest(unittest.TestCase):
         self.datamanager = get_multiclass_classification_datamanager()
         self.tmp = os.path.join(os.getcwd(), '.test_evaluation')
         os.mkdir(self.tmp)
-        self.logger = logging.getLogger()
+        self.logger_port = logging.handlers.DEFAULT_TCP_LOGGING_PORT
         scenario_mock = unittest.mock.Mock()
         scenario_mock.wallclock_limit = 10
         scenario_mock.algo_runs_timelimit = 1000
@@ -100,7 +100,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger=self.logger
+                                    logger_port=self.logger_port
                                     )
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
                                       instance_specific=None, seed=1, capped=False))
@@ -119,7 +119,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger=self.logger
+                                    logger_port=self.logger_port
                                     )
         self.stats.ta_runs = 1
         ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None, instance_specific=None,
@@ -144,7 +144,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger=self.logger
+                                    logger_port=self.logger_port
                                     )
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
                                       instance_specific=None, seed=1, capped=False))
@@ -163,7 +163,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger=self.logger
+                                    logger_port=self.logger_port
                                     )
         self.scenario.wallclock_limit = 5
         self.stats.submitted_ta_runs += 1
@@ -183,7 +183,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger=self.logger
+                                    logger_port=self.logger_port
                                     )
 
         # The following should not fail because abort on first config crashed is false
@@ -223,7 +223,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger=self.logger
+                                    logger_port=self.logger_port
                                     )
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
                                       instance_specific=None, seed=1, capped=False))
@@ -260,7 +260,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger=self.logger
+                                    logger_port=self.logger_port
                                     )
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
                                       instance_specific=None, seed=1, capped=False))
@@ -282,7 +282,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger=self.logger
+                                    logger_port=self.logger_port
                                     )
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
                                       instance_specific=None, seed=1, capped=False))
@@ -308,13 +308,13 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger=self.logger
+                                    logger_port=self.logger_port
                                     )
         self.scenario.wallclock_limit = 180
         instance = "{'subsample': 30}"
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=instance,
                                       instance_specific=None, seed=1, capped=False))
-        self.assertEqual(info[1].status, StatusType.SUCCESS)
+        self.assertEqual(info[1].status, StatusType.SUCCESS, info)
         self.assertEqual(len(info[1].additional_info), 2)
         self.assertIn('configuration_origin', info[1].additional_info)
         self.assertEqual(info[1].additional_info['message'], "{'subsample': 30}")
@@ -331,7 +331,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger=self.logger
+                                    logger_port=self.logger_port
                                     )
         self.stats.submitted_ta_runs += 1
         info = ta.run_wrapper(RunInfo(config=config, cutoff=30, instance=None,
@@ -353,7 +353,7 @@ class EvaluationTest(unittest.TestCase):
                                     metric=accuracy,
                                     cost_for_crash=get_cost_of_crash(accuracy),
                                     abort_on_first_run_crash=False,
-                                    logger=self.logger
+                                    logger_port=self.logger_port
                                     )
         ta.pynisher_logger = unittest.mock.Mock()
         self.stats.submitted_ta_runs += 1

--- a/test/test_pipeline/components/training/test_training.py
+++ b/test/test_pipeline/components/training/test_training.py
@@ -192,7 +192,7 @@ class StandardTrainerTest(BaseTraining, unittest.TestCase):
         counter = 0
         accuracy = 0
         while accuracy < 0.7:
-            loss, metrics = trainer.train_epoch(loader, epoch=1, logger=logger, writer=None)
+            loss, metrics = trainer.train_epoch(loader, epoch=1, writer=None)
             counter += 1
             accuracy = metrics['accuracy']
 
@@ -215,7 +215,7 @@ class MixUpTrainerTest(BaseTraining, unittest.TestCase):
         counter = 0
         accuracy = 0
         while accuracy < 0.7:
-            loss, metrics = trainer.train_epoch(loader, epoch=1, logger=logger, writer=None)
+            loss, metrics = trainer.train_epoch(loader, epoch=1, writer=None)
             counter += 1
             accuracy = metrics['accuracy']
 

--- a/test/test_pipeline/components/training/test_training.py
+++ b/test/test_pipeline/components/training/test_training.py
@@ -171,7 +171,7 @@ class StandardTrainerTest(BaseTraining, unittest.TestCase):
         counter = 0
         r2 = 0
         while r2 < 0.7:
-            loss, metrics = trainer.train_epoch(loader, epoch=1, logger=logger, writer=None)
+            loss, metrics = trainer.train_epoch(loader, epoch=1, writer=None)
             counter += 1
             r2 = metrics['r2']
 


### PR DESCRIPTION
Use the logger port instead of the logger for the TAE execution.

Add show_models() for debug purposes 

Remove tensorboard output because killing a run in the process of writing to disk halts the complete search process and python does not handle the recovery nice. This is something we should look fixing in pynisher.

Minor fixes like empty cuda in when not needed.