### PR TITLE
Updating the hyperparameter search space

### DIFF
--- a/autoPyTorch/pipeline/components/setup/network_backbone/MLPBackbone.py
+++ b/autoPyTorch/pipeline/components/setup/network_backbone/MLPBackbone.py
@@ -73,7 +73,7 @@ class MLPBackbone(NetworkBackboneComponent):
                                         activation: Tuple[Tuple, str] = (tuple(_activations.keys()),
                                                                          list(_activations.keys())[0]),
                                         use_dropout: Tuple[Tuple, bool] = ((True, False), False),
-                                        num_units: Tuple[Tuple, int] = ((10, 1024), 200),
+                                        num_units: Tuple[Tuple, int, bool] = ((10, 1024), 200, True),
                                         dropout: Tuple[Tuple, float] = ((0, 0.8), 0.5)
                                         ) -> ConfigurationSpace:
 
@@ -102,7 +102,9 @@ class MLPBackbone(NetworkBackboneComponent):
             n_units_hp = UniformIntegerHyperparameter("num_units_%d" % i,
                                                       lower=num_units[0][0],
                                                       upper=num_units[0][1],
-                                                      default_value=num_units[1])
+                                                      default_value=num_units[1],
+                                                      log=num_units[2],
+                                                      )
             cs.add_hyperparameter(n_units_hp)
 
             if i > min_mlp_layers:

--- a/autoPyTorch/pipeline/components/setup/network_backbone/ResNetBackbone.py
+++ b/autoPyTorch/pipeline/components/setup/network_backbone/ResNetBackbone.py
@@ -95,7 +95,7 @@ class ResNetBackbone(NetworkBackboneComponent):
     def get_hyperparameter_search_space(dataset_properties: Optional[Dict] = None,
                                         num_groups: Tuple[Tuple, int] = ((1, 15), 5),
                                         use_dropout: Tuple[Tuple, bool] = ((True, False), False),
-                                        num_units: Tuple[Tuple, int] = ((10, 1024), 200),
+                                        num_units: Tuple[Tuple, int, bool] = ((10, 1024), 200, True),
                                         activation: Tuple[Tuple, str] = (tuple(_activations.keys()),
                                                                          list(_activations.keys())[0]),
                                         blocks_per_group: Tuple[Tuple, int] = ((1, 4), 2),
@@ -145,7 +145,8 @@ class ResNetBackbone(NetworkBackboneComponent):
                 "num_units_%d" % i,
                 lower=num_units[0][0],
                 upper=num_units[0][1],
-                default_value=num_units[1]
+                default_value=num_units[1],
+                log=num_units[2],
             )
             blocks_per_group = UniformIntegerHyperparameter(
                 "blocks_per_group_%d" % i,

--- a/autoPyTorch/pipeline/components/setup/network_backbone/ShapedMLPBackbone.py
+++ b/autoPyTorch/pipeline/components/setup/network_backbone/ShapedMLPBackbone.py
@@ -79,8 +79,8 @@ class ShapedMLPBackbone(NetworkBackboneComponent):
                                         num_groups: Tuple[Tuple, int] = ((1, 15), 5),
                                         max_dropout: Tuple[Tuple, float] = ((0, 1), 0.5),
                                         use_dropout: Tuple[Tuple, bool] = ((True, False), False),
-                                        max_units: Tuple[Tuple, int] = ((10, 1024), 200),
-                                        output_dim: Tuple[Tuple, int] = ((10, 1024), 200),
+                                        max_units: Tuple[Tuple, int, bool] = ((10, 1024), 200, True),
+                                        output_dim: Tuple[Tuple, int, bool] = ((10, 1024), 200, True),
                                         mlp_shape: Tuple[Tuple, str] = (('funnel', 'long_funnel',
                                                                          'diamond', 'hexagon',
                                                                          'brick', 'triangle', 'stairs'), 'funnel'),
@@ -104,18 +104,22 @@ class ShapedMLPBackbone(NetworkBackboneComponent):
             default_value=activation[1]
         )
         (min_num_units, max_num_units), default_units = max_units[:2]
+        log_nr_max_units = max_units[2]
+
         max_units = UniformIntegerHyperparameter(
             "max_units",
             lower=min_num_units,
             upper=max_num_units,
             default_value=default_units,
+            log=log_nr_max_units,
         )
 
         output_dim = UniformIntegerHyperparameter(
             "output_dim",
             lower=output_dim[0][0],
             upper=output_dim[0][1],
-            default_value=output_dim[1]
+            default_value=output_dim[1],
+            log=output_dim[2],
         )
 
         cs.add_hyperparameters([num_groups, activation, mlp_shape, max_units, output_dim])

--- a/autoPyTorch/pipeline/components/setup/network_backbone/ShapedResNetBackbone.py
+++ b/autoPyTorch/pipeline/components/setup/network_backbone/ShapedResNetBackbone.py
@@ -83,7 +83,7 @@ class ShapedResNetBackbone(ResNetBackbone):
     def get_hyperparameter_search_space(dataset_properties: Optional[Dict] = None,  # type: ignore[override]
                                         num_groups: Tuple[Tuple, int] = ((1, 15), 5),
                                         use_dropout: Tuple[Tuple, bool] = ((True, False), False),
-                                        max_units: Tuple[Tuple, int] = ((10, 1024), 200),
+                                        max_units: Tuple[Tuple, int, bool] = ((10, 1024), 200, True),
                                         blocks_per_group: Tuple[Tuple, int] = ((1, 4), 2),
                                         max_dropout: Tuple[Tuple, float] = ((0, 0.8), 0.5),
                                         use_shake_shake: Tuple[Tuple, bool] = ((True, False), True),
@@ -94,7 +94,7 @@ class ShapedResNetBackbone(ResNetBackbone):
                                                                             'brick', 'triangle', 'stairs'), 'funnel'),
                                         activation: Tuple[Tuple, str] = (
                                         tuple(_activations.keys()), list(_activations.keys())[0]),
-                                        output_dim: Tuple[Tuple, int] = ((10, 1024), 200),
+                                        output_dim: Tuple[Tuple, int, bool] = ((10, 1024), 200, True),
                                         ) -> ConfigurationSpace:
         cs = ConfigurationSpace()
 
@@ -122,11 +122,14 @@ class ShapedResNetBackbone(ResNetBackbone):
             default_value=activation[1]
         )
         (min_num_units, max_num_units), default_units = max_units[:2]
+        log_num_units = max_units[2]
+
         output_dim = UniformIntegerHyperparameter(
             "output_dim",
             lower=output_dim[0][0],
             upper=output_dim[0][1],
-            default_value=output_dim[1]
+            default_value=output_dim[1],
+            log=output_dim[2],
         )
 
         cs.add_hyperparameters([num_groups, blocks_per_group, activation, output_dim])
@@ -147,7 +150,8 @@ class ShapedResNetBackbone(ResNetBackbone):
             "max_units",
             lower=min_num_units,
             upper=max_num_units,
-            default_value=default_units
+            default_value=default_units,
+            log=log_num_units,
         )
         cs.add_hyperparameters([max_units])
 

--- a/autoPyTorch/pipeline/components/setup/optimizer/AdamOptimizer.py
+++ b/autoPyTorch/pipeline/components/setup/optimizer/AdamOptimizer.py
@@ -77,7 +77,7 @@ class AdamOptimizer(BaseOptimizerComponent):
                                         lr: Tuple[Tuple, float, bool] = ((1e-5, 1e-1), 1e-2, True),
                                         beta1: Tuple[Tuple, float] = ((0.85, 0.999), 0.9),
                                         beta2: Tuple[Tuple, float] = ((0.9, 0.9999), 0.9),
-                                        weight_decay: Tuple[Tuple, float] = ((0.0, 0.1), 0.0)
+                                        weight_decay: Tuple[Tuple, float, bool] = ((0.0, 0.1), 0.0, True)
                                         ) -> ConfigurationSpace:
 
         cs = ConfigurationSpace()
@@ -93,7 +93,7 @@ class AdamOptimizer(BaseOptimizerComponent):
                                            default_value=beta2[1])
 
         weight_decay = UniformFloatHyperparameter('weight_decay', lower=weight_decay[0][0], upper=weight_decay[0][1],
-                                                  default_value=weight_decay[1])
+                                                  default_value=weight_decay[1], log=weight_decay[2])
 
         cs.add_hyperparameters([lr, beta1, beta2, weight_decay])
 

--- a/autoPyTorch/pipeline/components/setup/optimizer/AdamWOptimizer.py
+++ b/autoPyTorch/pipeline/components/setup/optimizer/AdamWOptimizer.py
@@ -77,7 +77,7 @@ class AdamWOptimizer(BaseOptimizerComponent):
                                         lr: Tuple[Tuple, float, bool] = ((1e-5, 1e-1), 1e-2, True),
                                         beta1: Tuple[Tuple, float] = ((0.85, 0.999), 0.9),
                                         beta2: Tuple[Tuple, float] = ((0.9, 0.9999), 0.9),
-                                        weight_decay: Tuple[Tuple, float] = ((0.0, 0.1), 0.0)
+                                        weight_decay: Tuple[Tuple, float, bool] = ((0.0, 0.1), 0.0, True)
                                         ) -> ConfigurationSpace:
 
         cs = ConfigurationSpace()
@@ -93,7 +93,7 @@ class AdamWOptimizer(BaseOptimizerComponent):
                                            default_value=beta2[1])
 
         weight_decay = UniformFloatHyperparameter('weight_decay', lower=weight_decay[0][0], upper=weight_decay[0][1],
-                                                  default_value=weight_decay[1])
+                                                  default_value=weight_decay[1], log=weight_decay[2])
 
         cs.add_hyperparameters([lr, beta1, beta2, weight_decay])
 

--- a/autoPyTorch/pipeline/components/setup/optimizer/RMSpropOptimizer.py
+++ b/autoPyTorch/pipeline/components/setup/optimizer/RMSpropOptimizer.py
@@ -79,7 +79,7 @@ class RMSpropOptimizer(BaseOptimizerComponent):
     def get_hyperparameter_search_space(dataset_properties: Optional[Dict] = None,
                                         lr: Tuple[Tuple, float, bool] = ((1e-5, 1e-1), 1e-2, True),
                                         alpha: Tuple[Tuple, float] = ((0.1, 0.99), 0.99),
-                                        weight_decay: Tuple[Tuple, float] = ((0.0, 0.1), 0.0),
+                                        weight_decay: Tuple[Tuple, float, bool] = ((0.0, 0.1), 0.0, True),
                                         momentum: Tuple[Tuple, float] = ((0.0, 0.99), 0.0),
                                         ) -> ConfigurationSpace:
 
@@ -93,7 +93,7 @@ class RMSpropOptimizer(BaseOptimizerComponent):
                                            default_value=alpha[1])
 
         weight_decay = UniformFloatHyperparameter('weight_decay', lower=weight_decay[0][0], upper=weight_decay[0][1],
-                                                  default_value=weight_decay[1])
+                                                  default_value=weight_decay[1], log=weight_decay[2])
 
         momentum = UniformFloatHyperparameter('momentum', lower=momentum[0][0], upper=momentum[0][1],
                                               default_value=momentum[1])

--- a/autoPyTorch/pipeline/components/setup/optimizer/SGDOptimizer.py
+++ b/autoPyTorch/pipeline/components/setup/optimizer/SGDOptimizer.py
@@ -72,7 +72,7 @@ class SGDOptimizer(BaseOptimizerComponent):
     @staticmethod
     def get_hyperparameter_search_space(dataset_properties: Optional[Dict] = None,
                                         lr: Tuple[Tuple, float, bool] = ((1e-5, 1e-1), 1e-2, True),
-                                        weight_decay: Tuple[Tuple, float] = ((0.0, 0.1), 0.0),
+                                        weight_decay: Tuple[Tuple, float, bool] = ((0.0, 0.1), 0.0, True),
                                         momentum: Tuple[Tuple, float] = ((0.0, 0.99), 0.0),
                                         ) -> ConfigurationSpace:
 
@@ -83,7 +83,7 @@ class SGDOptimizer(BaseOptimizerComponent):
                                         default_value=lr[1], log=lr[2])
 
         weight_decay = UniformFloatHyperparameter('weight_decay', lower=weight_decay[0][0], upper=weight_decay[0][1],
-                                                  default_value=weight_decay[1])
+                                                  default_value=weight_decay[1], log=weight_decay[2])
 
         momentum = UniformFloatHyperparameter('momentum', lower=momentum[0][0], upper=momentum[0][1],
                                               default_value=momentum[1])

--- a/autoPyTorch/pipeline/components/training/data_loader/base_data_loader.py
+++ b/autoPyTorch/pipeline/components/training/data_loader/base_data_loader.py
@@ -249,10 +249,15 @@ class BaseDataLoaderComponent(autoPyTorchTrainingComponent):
 
     @staticmethod
     def get_hyperparameter_search_space(dataset_properties: Optional[Dict] = None,
-                                        batch_size: Tuple[Tuple, int] = ((32, 320), 64)
+                                        batch_size: Tuple[Tuple, int, bool] = ((32, 320), 64, True)
                                         ) -> ConfigurationSpace:
         batch_size = UniformIntegerHyperparameter(
-            "batch_size", batch_size[0][0], batch_size[0][1], default_value=batch_size[1])
+            "batch_size",
+            batch_size[0][0],
+            batch_size[0][1],
+            default_value=batch_size[1],
+            log=batch_size[2],
+        )
         cs = ConfigurationSpace()
         cs.add_hyperparameters([batch_size])
         return cs


### PR DESCRIPTION
Given the recent experiments with the cocktails, I think the hyperparameter search space needs this update in the case when the architecture is not restricted. And this is a general update and not only related to the cocktails.

https://arxiv.org/abs/2006.13799

Matches the search space from the paper above and adds log sampled `weight decay` values.