### PR TITLE
[Feature] Get incumbent config and results

### DIFF
--- a/autoPyTorch/api/base_task.py
+++ b/autoPyTorch/api/base_task.py
@@ -1247,15 +1247,17 @@ class BaseTask:
 
     @typing.no_type_check
     def get_incumbent_results(
-            self
+        self,
+        include_traditional: bool = False
     ):
-        pass
+        assert self.run_history is not None, "No Run History found, search has not been called."
+        assert not self.run_history.empty(), "Run History is empty."
 
-    @typing.no_type_check
-    def get_incumbent_config(
-            self
-    ):
-        pass
+        sorted_runvalue_by_cost = sorted(self.run_history.data.items(), key=lambda item: item[1].cost)
+        incumbent_run_key, incumbent_run_value = sorted_runvalue_by_cost[0]
+        incumbent_config = self.run_history.ids_config[incumbent_run_key.config_id]
+        incumbent_results = incumbent_run_value.additional_info
+        return incumbent_config, incumbent_results
 
     def get_models_with_weights(self) -> List:
         if self.models_ is None or len(self.models_) == 0 or \

--- a/autoPyTorch/api/base_task.py
+++ b/autoPyTorch/api/base_task.py
@@ -1242,20 +1242,23 @@ class BaseTask:
     def get_incumbent_results(
         self,
         include_traditional: bool = False
-    ) -> Tuple[Configuration, Dict]:
+    ) -> Tuple[Configuration, Dict[str, Union[int, str, float]]]:
         """
         Get Incumbent config and the corresponding results
         Args:
-            include_traditional:
+            include_traditional: Whether to include results from tradtional pipelines
 
         Returns:
 
         """
         assert self.run_history is not None, "No Run History found, search has not been called."
-        assert not self.run_history.empty(), "Run History is empty."
+        if self.run_history.empty():
+            raise ValueError("Run History is empty. Something went wrong, "
+                             "smac was not able to fit any model?")
 
         run_history_data = self.run_history.data
         if not include_traditional:
+            # traditional classifiers have trainer_configuration in their additional info
             run_history_data = dict(
                 filter(lambda elem: elem[1].additional_info is not None and 'trainer_configuration' not in elem[1].
                        additional_info,

--- a/autoPyTorch/evaluation/abstract_evaluator.py
+++ b/autoPyTorch/evaluation/abstract_evaluator.py
@@ -481,8 +481,7 @@ class AbstractEvaluator(object):
         additional_run_info = (
             {} if additional_run_info is None else additional_run_info
         )
-        for metric_name, value in loss.items():
-            additional_run_info[metric_name] = value
+        additional_run_info['opt_loss'] = loss
         additional_run_info['duration'] = self.duration
         additional_run_info['num_run'] = self.num_run
         if train_loss is not None:

--- a/test/test_api/test_api.py
+++ b/test/test_api/test_api.py
@@ -3,6 +3,8 @@ import pickle
 import sys
 import unittest
 
+from ConfigSpace.configuration_space import Configuration
+
 import numpy as np
 
 import pandas as pd
@@ -177,6 +179,13 @@ def test_tabular_classification(openml_id, resampling_strategy, backend):
     score = estimator.score(y_pred, y_test)
     assert 'accuracy' in score
 
+    # check incumbent config and results
+    incumbent_config, incumbent_results = estimator.get_incumbent_results()
+    assert isinstance(incumbent_config, Configuration)
+    assert isinstance(incumbent_results, dict)
+    assert 'opt_loss' in incumbent_results
+    assert 'train_loss' in incumbent_results
+
     # Check that we can pickle
     # Test pickle
     # This can happen on python greater than 3.6
@@ -346,6 +355,13 @@ def test_tabular_regression(openml_name, resampling_strategy, backend):
 
     score = estimator.score(y_pred, y_test)
     assert 'r2' in score
+
+    # check incumbent config and results
+    incumbent_config, incumbent_results = estimator.get_incumbent_results()
+    assert isinstance(incumbent_config, Configuration)
+    assert isinstance(incumbent_results, dict)
+    assert 'opt_loss' in incumbent_results
+    assert 'train_loss' in incumbent_results
 
     # Check that we can pickle
     # Test pickle


### PR DESCRIPTION
Fixes #150 

Changes made-
1. removed `get_incumbent_config` from base task as it would be redundant to have two separate functions for getting configuration and the results
2. `get_incumbent_results` goes through the run history and gets the config that has the minimum cost on the validation set.
3. Also returns the additional info which includes optimisation loss on the other metrics specified  and the train loss.
4. Adds test to check if the function is working properly