### PR TITLE
fix bug in backend next_num_run

### DIFF
--- a/autoPyTorch/utils/backend.py
+++ b/autoPyTorch/utils/backend.py
@@ -361,7 +361,7 @@ class Backend(object):
         other_num_runs = [int(os.path.basename(run_dir).split('_')[1])
                           for run_dir in glob.glob(os.path.join(self.internals_directory,
                                                                 'runs',
-                                                                '*'))]
+                                                                '*')) if '_' in os.path.basename(run_dir)]
         if len(other_num_runs) > 0:
             # We track the number of runs from two forefronts:
             # The physically available num_runs (which might be deleted or a crash could happen)


### PR DESCRIPTION
Fixes the bug while getting next num run in backend. It ignores the folders that are not in the correct format. 