### PR TITLE
[fix] Change get_components to classmethod to narrow the scope

### DIFF
--- a/autoPyTorch/pipeline/components/base_choice.py
+++ b/autoPyTorch/pipeline/components/base_choice.py
@@ -61,6 +61,7 @@ class autoPyTorchChoice(object):
                                  " but got None, to get fit requirements for {}, "
                                  "call get_fit_requirements of the component".format(self.__class__.__name__))
 
+    @classmethod
     def get_components(cls: 'autoPyTorchChoice') -> Dict[str, autoPyTorchComponent]:
         """Returns and ordered dict with the components available
         for current step.

--- a/autoPyTorch/pipeline/components/preprocessing/image_preprocessing/normalise/base_normalizer_choice.py
+++ b/autoPyTorch/pipeline/components/preprocessing/image_preprocessing/normalise/base_normalizer_choice.py
@@ -14,24 +14,22 @@ from autoPyTorch.pipeline.components.base_component import (
 from autoPyTorch.pipeline.components.preprocessing.image_preprocessing.normalise.base_normalizer import BaseNormalizer
 
 
-normalise_directory = os.path.split(__file__)[0]
-_normalizers = find_components(__package__,
-                               normalise_directory,
-                               BaseNormalizer)
-
-_addons = ThirdPartyComponents(BaseNormalizer)
-
-
-def add_normalizer(normalizer: BaseNormalizer) -> None:
-    _addons.add_component(normalizer)
-
-
 class NormalizerChoice(autoPyTorchChoice):
     """
     Allows for dynamically choosing encoding component at runtime
     """
+    _normalizers = find_components(__package__,
+                                   os.path.split(__file__)[0],
+                                   BaseNormalizer)
 
-    def get_components(self) -> Dict[str, autoPyTorchComponent]:
+    _addons = ThirdPartyComponents(BaseNormalizer)
+
+    @classmethod
+    def add_normalizer(cls, normalizer: BaseNormalizer) -> None:
+        cls._addons.add_component(normalizer)
+
+    @classmethod
+    def get_components(cls) -> Dict[str, autoPyTorchComponent]:
         """Returns the available normalizer components
 
         Args:
@@ -42,8 +40,8 @@ class NormalizerChoice(autoPyTorchChoice):
                 as choices for encoding the categorical columns
         """
         components = OrderedDict()
-        components.update(_normalizers)
-        components.update(_addons.components)
+        components.update(cls._normalizers)
+        components.update(cls._addons.components)
         return components
 
     def get_hyperparameter_search_space(self,

--- a/autoPyTorch/pipeline/components/preprocessing/tabular_preprocessing/encoding/base_encoder_choice.py
+++ b/autoPyTorch/pipeline/components/preprocessing/tabular_preprocessing/encoding/base_encoder_choice.py
@@ -14,23 +14,21 @@ from autoPyTorch.pipeline.components.base_component import (
 from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.encoding.base_encoder import BaseEncoder
 
 
-encoding_directory = os.path.split(__file__)[0]
-_encoders = find_components(__package__,
-                            encoding_directory,
-                            BaseEncoder)
-_addons = ThirdPartyComponents(BaseEncoder)
-
-
-def add_encoder(encoder: BaseEncoder) -> None:
-    _addons.add_component(encoder)
-
-
 class EncoderChoice(autoPyTorchChoice):
     """
     Allows for dynamically choosing encoding component at runtime
     """
+    _encoders = find_components(__package__,
+                                os.path.split(__file__)[0],
+                                BaseEncoder)
+    _addons = ThirdPartyComponents(BaseEncoder)
 
-    def get_components(self) -> Dict[str, autoPyTorchComponent]:
+    @classmethod
+    def add_encoder(cls, encoder: BaseEncoder) -> None:
+        cls._addons.add_component(encoder)
+
+    @classmethod
+    def get_components(cls) -> Dict[str, autoPyTorchComponent]:
         """Returns the available encoder components
 
         Args:
@@ -41,8 +39,8 @@ class EncoderChoice(autoPyTorchChoice):
                 as choices for encoding the categorical columns
         """
         components = OrderedDict()
-        components.update(_encoders)
-        components.update(_addons.components)
+        components.update(cls._encoders)
+        components.update(cls._addons.components)
         return components
 
     def get_hyperparameter_search_space(self,

--- a/autoPyTorch/pipeline/components/preprocessing/tabular_preprocessing/feature_preprocessing/base_feature_preprocessor_choice.py
+++ b/autoPyTorch/pipeline/components/preprocessing/tabular_preprocessing/feature_preprocessing/base_feature_preprocessor_choice.py
@@ -14,23 +14,22 @@ from autoPyTorch.pipeline.components.base_component import (
 from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.feature_preprocessing. \
     base_feature_preprocessor import autoPyTorchFeaturePreprocessingComponent
 
-preprocessing_directory = os.path.split(__file__)[0]
-_preprocessors = find_components(__package__,
-                                 preprocessing_directory,
-                                 autoPyTorchFeaturePreprocessingComponent)
-_addons = ThirdPartyComponents(autoPyTorchFeaturePreprocessingComponent)
 
-
-def add_feature_preprocessor(feature_preprocessor: autoPyTorchFeaturePreprocessingComponent) -> None:
-    _addons.add_component(feature_preprocessor)
-
-
-class FeatureProprocessorChoice(autoPyTorchChoice):
+class FeaturePreprocessorChoice(autoPyTorchChoice):
     """
     Allows for dynamically choosing feature_preprocessor component at runtime
     """
+    _preprocessors = find_components(__package__,
+                                     os.path.split(__file__)[0],
+                                     autoPyTorchFeaturePreprocessingComponent)
+    _addons = ThirdPartyComponents(autoPyTorchFeaturePreprocessingComponent)
 
-    def get_components(self) -> Dict[str, autoPyTorchComponent]:
+    @classmethod
+    def add_feature_preprocessor(cls, feature_preprocessor: autoPyTorchFeaturePreprocessingComponent) -> None:
+        cls._addons.add_component(feature_preprocessor)
+
+    @classmethod
+    def get_components(cls) -> Dict[str, autoPyTorchComponent]:
         """Returns the available feature_preprocessor components
 
         Args:
@@ -41,8 +40,8 @@ class FeatureProprocessorChoice(autoPyTorchChoice):
                 as choices for encoding the categorical columns
         """
         components: Dict = OrderedDict()
-        components.update(_preprocessors)
-        components.update(_addons.components)
+        components.update(cls._preprocessors)
+        components.update(cls._addons.components)
         return components
 
     def get_hyperparameter_search_space(self,

--- a/autoPyTorch/pipeline/components/preprocessing/tabular_preprocessing/scaling/base_scaler_choice.py
+++ b/autoPyTorch/pipeline/components/preprocessing/tabular_preprocessing/scaling/base_scaler_choice.py
@@ -13,24 +13,23 @@ from autoPyTorch.pipeline.components.base_component import (
 )
 from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.scaling.base_scaler import BaseScaler
 
-scaling_directory = os.path.split(__file__)[0]
-_scalers = find_components(__package__,
-                           scaling_directory,
-                           BaseScaler)
-
-_addons = ThirdPartyComponents(BaseScaler)
-
-
-def add_scaler(scaler: BaseScaler) -> None:
-    _addons.add_component(scaler)
-
 
 class ScalerChoice(autoPyTorchChoice):
     """
     Allows for dynamically choosing scaling component at runtime
     """
+    _scalers = find_components(__package__,
+                               os.path.split(__file__)[0],
+                               BaseScaler)
 
-    def get_components(self) -> Dict[str, autoPyTorchComponent]:
+    _addons = ThirdPartyComponents(BaseScaler)
+
+    @classmethod
+    def add_scaler(cls, scaler: BaseScaler) -> None:
+        cls._addons.add_component(scaler)
+
+    @classmethod
+    def get_components(cls) -> Dict[str, autoPyTorchComponent]:
         """Returns the available scaler components
 
         Args:
@@ -41,8 +40,8 @@ class ScalerChoice(autoPyTorchChoice):
                 as choices for scaling
         """
         components = OrderedDict()
-        components.update(_scalers)
-        components.update(_addons.components)
+        components.update(cls._scalers)
+        components.update(cls._addons.components)
         return components
 
     def get_hyperparameter_search_space(self,

--- a/autoPyTorch/pipeline/components/setup/lr_scheduler/base_scheduler_choice.py
+++ b/autoPyTorch/pipeline/components/setup/lr_scheduler/base_scheduler_choice.py
@@ -15,20 +15,19 @@ from autoPyTorch.pipeline.components.base_component import (
 )
 from autoPyTorch.pipeline.components.setup.lr_scheduler.base_scheduler import BaseLRComponent
 
-directory = os.path.split(__file__)[0]
-_schedulers = find_components(__package__,
-                              directory,
-                              BaseLRComponent)
-_addons = ThirdPartyComponents(BaseLRComponent)
-
-
-def add_scheduler(scheduler: BaseLRComponent) -> None:
-    _addons.add_component(scheduler)
-
 
 class SchedulerChoice(autoPyTorchChoice):
+    _schedulers = find_components(__package__,
+                                  os.path.split(__file__)[0],
+                                  BaseLRComponent)
+    _addons = ThirdPartyComponents(BaseLRComponent)
 
-    def get_components(self) -> Dict[str, autoPyTorchComponent]:
+    @classmethod
+    def add_scheduler(cls, scheduler: BaseLRComponent) -> None:
+        cls._addons.add_component(scheduler)
+
+    @classmethod
+    def get_components(cls) -> Dict[str, autoPyTorchComponent]:
         """Returns the available scheduler components
 
         Args:
@@ -39,8 +38,8 @@ class SchedulerChoice(autoPyTorchChoice):
                 as choices for learning rate scheduling
         """
         components = OrderedDict()
-        components.update(_schedulers)
-        components.update(_addons.components)
+        components.update(cls._schedulers)
+        components.update(cls._addons.components)
         return components
 
     def get_available_components(
@@ -72,7 +71,7 @@ class SchedulerChoice(autoPyTorchChoice):
             raise ValueError(
                 "The argument include and exclude cannot be used together.")
 
-        available_comp = self.get_components()
+        available_comp = SchedulerChoice.get_components()
 
         if include is not None:
             for incl in include:

--- a/autoPyTorch/pipeline/components/setup/network_backbone/base_network_backbone_choice.py
+++ b/autoPyTorch/pipeline/components/setup/network_backbone/base_network_backbone_choice.py
@@ -17,20 +17,19 @@ from autoPyTorch.pipeline.components.setup.network_backbone.base_network_backbon
     NetworkBackboneComponent,
 )
 
-directory = os.path.split(__file__)[0]
-_backbones = find_components(__package__,
-                             directory,
-                             NetworkBackboneComponent)
-_addons = ThirdPartyComponents(NetworkBackboneComponent)
-
-
-def add_backbone(backbone: NetworkBackboneComponent) -> None:
-    _addons.add_component(backbone)
-
 
 class NetworkBackboneChoice(autoPyTorchChoice):
+    _backbones = find_components(__package__,
+                                 os.path.split(__file__)[0],
+                                 NetworkBackboneComponent)
+    _addons = ThirdPartyComponents(NetworkBackboneComponent)
 
-    def get_components(self) -> Dict[str, autoPyTorchComponent]:
+    @classmethod
+    def add_backbone(cls, backbone: NetworkBackboneComponent) -> None:
+        cls._addons.add_component(backbone)
+
+    @classmethod
+    def get_components(cls) -> Dict[str, autoPyTorchComponent]:
         """Returns the available backbone components
 
         Args:
@@ -41,8 +40,8 @@ class NetworkBackboneChoice(autoPyTorchChoice):
                 as choices for learning rate scheduling
         """
         components = OrderedDict()
-        components.update(_backbones)
-        components.update(_addons.components)
+        components.update(cls._backbones)
+        components.update(cls._addons.components)
         return components
 
     def get_available_components(
@@ -74,7 +73,7 @@ class NetworkBackboneChoice(autoPyTorchChoice):
             raise ValueError(
                 "The argument include and exclude cannot be used together.")
 
-        available_comp = self.get_components()
+        available_comp = NetworkBackboneChoice.get_components()
 
         if include is not None:
             for incl in include:

--- a/autoPyTorch/pipeline/components/setup/network_embedding/base_network_embedding_choice.py
+++ b/autoPyTorch/pipeline/components/setup/network_embedding/base_network_embedding_choice.py
@@ -17,20 +17,19 @@ from autoPyTorch.pipeline.components.setup.network_embedding.base_network_embedd
     NetworkEmbeddingComponent,
 )
 
-directory = os.path.split(__file__)[0]
-_embeddings = find_components(__package__,
-                              directory,
-                              NetworkEmbeddingComponent)
-_addons = ThirdPartyComponents(NetworkEmbeddingComponent)
-
-
-def add_embedding(embedding: NetworkEmbeddingComponent) -> None:
-    _addons.add_component(embedding)
-
 
 class NetworkEmbeddingChoice(autoPyTorchChoice):
+    _embeddings = find_components(__package__,
+                                  os.path.split(__file__)[0],
+                                  NetworkEmbeddingComponent)
+    _addons = ThirdPartyComponents(NetworkEmbeddingComponent)
 
-    def get_components(self) -> Dict[str, autoPyTorchComponent]:
+    @classmethod
+    def add_embedding(cls, embedding: NetworkEmbeddingComponent) -> None:
+        cls._addons.add_component(embedding)
+
+    @classmethod
+    def get_components(cls) -> Dict[str, autoPyTorchComponent]:
         """Returns the available embedding components
 
         Args:
@@ -41,8 +40,8 @@ class NetworkEmbeddingChoice(autoPyTorchChoice):
                 as choices for learning rate scheduling
         """
         components = OrderedDict()
-        components.update(_embeddings)
-        components.update(_addons.components)
+        components.update(cls._embeddings)
+        components.update(cls._addons.components)
         return components
 
     def get_available_components(
@@ -74,7 +73,7 @@ class NetworkEmbeddingChoice(autoPyTorchChoice):
             raise ValueError(
                 "The argument include and exclude cannot be used together.")
 
-        available_comp = self.get_components()
+        available_comp = NetworkEmbeddingChoice.get_components()
 
         if include is not None:
             for incl in include:

--- a/autoPyTorch/pipeline/components/setup/network_head/base_network_head_choice.py
+++ b/autoPyTorch/pipeline/components/setup/network_head/base_network_head_choice.py
@@ -17,20 +17,19 @@ from autoPyTorch.pipeline.components.setup.network_head.base_network_head import
     NetworkHeadComponent,
 )
 
-directory = os.path.split(__file__)[0]
-_heads = find_components(__package__,
-                         directory,
-                         NetworkHeadComponent)
-_addons = ThirdPartyComponents(NetworkHeadComponent)
-
-
-def add_head(head: NetworkHeadComponent) -> None:
-    _addons.add_component(head)
-
 
 class NetworkHeadChoice(autoPyTorchChoice):
+    _heads = find_components(__package__,
+                             os.path.split(__file__)[0],
+                             NetworkHeadComponent)
+    _addons = ThirdPartyComponents(NetworkHeadComponent)
 
-    def get_components(self) -> Dict[str, autoPyTorchComponent]:
+    @classmethod
+    def add_head(cls, head: NetworkHeadComponent) -> None:
+        cls._addons.add_component(head)
+
+    @classmethod
+    def get_components(cls) -> Dict[str, autoPyTorchComponent]:
         """Returns the available head components
 
         Args:
@@ -41,8 +40,8 @@ class NetworkHeadChoice(autoPyTorchChoice):
                 as choices for learning rate scheduling
         """
         components = OrderedDict()
-        components.update(_heads)
-        components.update(_addons.components)
+        components.update(cls._heads)
+        components.update(cls._addons.components)
         return components
 
     def get_available_components(
@@ -74,7 +73,7 @@ class NetworkHeadChoice(autoPyTorchChoice):
             raise ValueError(
                 "The argument include and exclude cannot be used together.")
 
-        available_comp = self.get_components()
+        available_comp = NetworkHeadChoice.get_components()
 
         if include is not None:
             for incl in include:

--- a/autoPyTorch/pipeline/components/setup/network_initializer/base_network_init_choice.py
+++ b/autoPyTorch/pipeline/components/setup/network_initializer/base_network_init_choice.py
@@ -17,20 +17,19 @@ from autoPyTorch.pipeline.components.setup.network_initializer.base_network_init
     BaseNetworkInitializerComponent
 )
 
-directory = os.path.split(__file__)[0]
-_initializers = find_components(__package__,
-                                directory,
-                                BaseNetworkInitializerComponent)
-_addons = ThirdPartyComponents(BaseNetworkInitializerComponent)
-
-
-def add_network_initializer(initializer: BaseNetworkInitializerComponent) -> None:
-    _addons.add_component(initializer)
-
 
 class NetworkInitializerChoice(autoPyTorchChoice):
+    _initializers = find_components(__package__,
+                                    os.path.split(__file__)[0],
+                                    BaseNetworkInitializerComponent)
+    _addons = ThirdPartyComponents(BaseNetworkInitializerComponent)
 
-    def get_components(self) -> Dict[str, autoPyTorchComponent]:
+    @classmethod
+    def add_network_initializer(cls, initializer: BaseNetworkInitializerComponent) -> None:
+        cls._addons.add_component(initializer)
+
+    @classmethod
+    def get_components(cls) -> Dict[str, autoPyTorchComponent]:
         """Returns the available initializer components
 
         Args:
@@ -41,8 +40,8 @@ class NetworkInitializerChoice(autoPyTorchChoice):
                 as choices
         """
         components = OrderedDict()
-        components.update(_initializers)
-        components.update(_addons.components)
+        components.update(cls._initializers)
+        components.update(cls._addons.components)
         return components
 
     def get_available_components(
@@ -73,7 +72,7 @@ class NetworkInitializerChoice(autoPyTorchChoice):
             raise ValueError(
                 "The argument include and exclude cannot be used together.")
 
-        available_comp = self.get_components()
+        available_comp = NetworkInitializerChoice.get_components()
 
         if include is not None:
             for incl in include:

--- a/autoPyTorch/pipeline/components/setup/optimizer/base_optimizer_choice.py
+++ b/autoPyTorch/pipeline/components/setup/optimizer/base_optimizer_choice.py
@@ -15,20 +15,19 @@ from autoPyTorch.pipeline.components.base_component import (
 )
 from autoPyTorch.pipeline.components.setup.optimizer.base_optimizer import BaseOptimizerComponent
 
-directory = os.path.split(__file__)[0]
-_optimizers = find_components(__package__,
-                              directory,
-                              BaseOptimizerComponent)
-_addons = ThirdPartyComponents(BaseOptimizerComponent)
-
-
-def add_optimizer(optimizer: BaseOptimizerComponent) -> None:
-    _addons.add_component(optimizer)
-
 
 class OptimizerChoice(autoPyTorchChoice):
+    _optimizers = find_components(__package__,
+                                  os.path.split(__file__)[0],
+                                  BaseOptimizerComponent)
+    _addons = ThirdPartyComponents(BaseOptimizerComponent)
 
-    def get_components(self) -> Dict[str, autoPyTorchComponent]:
+    @classmethod
+    def add_optimizer(cls, optimizer: BaseOptimizerComponent) -> None:
+        cls._addons.add_component(optimizer)
+
+    @classmethod
+    def get_components(cls) -> Dict[str, autoPyTorchComponent]:
         """Returns the available optimizer components
 
         Args:
@@ -39,8 +38,8 @@ class OptimizerChoice(autoPyTorchChoice):
                 as choices
         """
         components = OrderedDict()
-        components.update(_optimizers)
-        components.update(_addons.components)
+        components.update(cls._optimizers)
+        components.update(cls._addons.components)
         return components
 
     def get_available_components(
@@ -71,7 +70,7 @@ class OptimizerChoice(autoPyTorchChoice):
             raise ValueError(
                 "The argument include and exclude cannot be used together.")
 
-        available_comp = self.get_components()
+        available_comp = OptimizerChoice.get_components()
 
         if include is not None:
             for incl in include:

--- a/autoPyTorch/pipeline/components/setup/traditional_ml/base_model_choice.py
+++ b/autoPyTorch/pipeline/components/setup/traditional_ml/base_model_choice.py
@@ -16,20 +16,18 @@ from autoPyTorch.pipeline.components.base_component import (
 from autoPyTorch.pipeline.components.setup.traditional_ml.base_model import BaseModelComponent
 
 
-directory = os.path.split(__file__)[0]
-_models = find_components(__package__,
-                          directory,
-                          BaseModelComponent)
-_addons = ThirdPartyComponents(BaseModelComponent)
-
-
-def add_model(model: BaseModelComponent) -> None:
-    _addons.add_component(model)
-
-
 class ModelChoice(autoPyTorchChoice):
+    _models = find_components(__package__,
+                              os.path.split(__file__)[0],
+                              BaseModelComponent)
+    _addons = ThirdPartyComponents(BaseModelComponent)
 
-    def get_components(self) -> Dict[str, autoPyTorchComponent]:
+    @classmethod
+    def add_model(cls, model: BaseModelComponent) -> None:
+        cls._addons.add_component(model)
+
+    @classmethod
+    def get_components(cls) -> Dict[str, autoPyTorchComponent]:
         """Returns the available model components
         Args:
             None
@@ -38,8 +36,8 @@ class ModelChoice(autoPyTorchChoice):
                 as choices
         """
         components = OrderedDict()
-        components.update(_models)
-        components.update(_addons.components)
+        components.update(cls._models)
+        components.update(cls._addons.components)
         return components
 
     def get_available_components(
@@ -68,7 +66,7 @@ class ModelChoice(autoPyTorchChoice):
             raise ValueError(
                 "The argument include and exclude cannot be used together.")
 
-        available_comp = self.get_components()
+        available_comp = ModelChoice.get_components()
 
         if include is not None:
             for incl in include:

--- a/autoPyTorch/pipeline/tabular_classification.py
+++ b/autoPyTorch/pipeline/tabular_classification.py
@@ -22,7 +22,7 @@ from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.encodin
     EncoderChoice
 )
 from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.feature_preprocessing. \
-    base_feature_preprocessor_choice import FeatureProprocessorChoice
+    base_feature_preprocessor_choice import FeaturePreprocessorChoice
 from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.imputation.SimpleImputer import SimpleImputer
 from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.scaling.base_scaler_choice import ScalerChoice
 from autoPyTorch.pipeline.components.setup.early_preprocessor.EarlyPreprocessing import EarlyPreprocessing
@@ -248,7 +248,7 @@ class TabularClassificationPipeline(ClassifierMixin, BasePipeline):
             ("imputer", SimpleImputer(random_state=self.random_state)),
             ("encoder", EncoderChoice(default_dataset_properties, random_state=self.random_state)),
             ("scaler", ScalerChoice(default_dataset_properties, random_state=self.random_state)),
-            ("feature_preprocessor", FeatureProprocessorChoice(default_dataset_properties,
+            ("feature_preprocessor", FeaturePreprocessorChoice(default_dataset_properties,
                                                                random_state=self.random_state)),
             ("tabular_transformer", TabularColumnTransformer(random_state=self.random_state)),
             ("preprocessing", EarlyPreprocessing(random_state=self.random_state)),

--- a/autoPyTorch/pipeline/tabular_regression.py
+++ b/autoPyTorch/pipeline/tabular_regression.py
@@ -20,7 +20,7 @@ from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.encodin
     EncoderChoice
 )
 from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.feature_preprocessing. \
-    base_feature_preprocessor_choice import FeatureProprocessorChoice
+    base_feature_preprocessor_choice import FeaturePreprocessorChoice
 from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.imputation.SimpleImputer import SimpleImputer
 from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.scaling.base_scaler_choice import ScalerChoice
 from autoPyTorch.pipeline.components.setup.early_preprocessor.EarlyPreprocessing import EarlyPreprocessing
@@ -192,7 +192,7 @@ class TabularRegressionPipeline(RegressorMixin, BasePipeline):
             ("imputer", SimpleImputer(random_state=self.random_state)),
             ("encoder", EncoderChoice(default_dataset_properties, random_state=self.random_state)),
             ("scaler", ScalerChoice(default_dataset_properties, random_state=self.random_state)),
-            ("feature_preprocessor", FeatureProprocessorChoice(default_dataset_properties,
+            ("feature_preprocessor", FeaturePreprocessorChoice(default_dataset_properties,
                                                                random_state=self.random_state)),
             ("tabular_transformer", TabularColumnTransformer(random_state=self.random_state)),
             ("preprocessing", EarlyPreprocessing(random_state=self.random_state)),

--- a/test/test_pipeline/components/preprocessing/test_encoder_choice.py
+++ b/test/test_pipeline/components/preprocessing/test_encoder_choice.py
@@ -17,7 +17,7 @@ class TestEncoderChoice(unittest.TestCase):
         # Make sure that all hyperparameters are part of the search space
         self.assertListEqual(
             sorted(cs.get_hyperparameter('__choice__').choices),
-            sorted(list(encoder_choice.get_components().keys()))
+            sorted(list(EncoderChoice.get_components().keys()))
         )
 
         # Make sure we can properly set some random configs
@@ -30,7 +30,7 @@ class TestEncoderChoice(unittest.TestCase):
             encoder_choice.set_hyperparameters(config)
 
             self.assertEqual(encoder_choice.choice.__class__,
-                             encoder_choice.get_components()[config_dict['__choice__']])
+                             EncoderChoice.get_components()[config_dict['__choice__']])
 
             # Then check the choice configuration
             selected_choice = config_dict.pop('__choice__', None)

--- a/test/test_pipeline/components/preprocessing/test_feature_preprocessor.py
+++ b/test/test_pipeline/components/preprocessing/test_feature_preprocessor.py
@@ -10,7 +10,7 @@ from sklearn.compose import make_column_transformer
 from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.feature_preprocessing. \
     NoFeaturePreprocessor import NoFeaturePreprocessor
 from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.feature_preprocessing. \
-    base_feature_preprocessor_choice import FeatureProprocessorChoice
+    base_feature_preprocessor_choice import FeaturePreprocessorChoice
 from autoPyTorch.pipeline.tabular_classification import TabularClassificationPipeline
 
 
@@ -25,9 +25,7 @@ def preprocessor(request):
 class TestFeaturePreprocessors:
 
     def test_feature_preprocessor(self, fit_dictionary_tabular, preprocessor):
-        preprocessor = FeatureProprocessorChoice(
-            dataset_properties=fit_dictionary_tabular['dataset_properties']
-        ).get_components()[preprocessor]()
+        preprocessor = FeaturePreprocessorChoice.get_components()[preprocessor]()
         configuration = preprocessor. \
             get_hyperparameter_search_space(dataset_properties=fit_dictionary_tabular["dataset_properties"]) \
             .get_default_configuration().get_dictionary()

--- a/test/test_pipeline/components/preprocessing/test_feature_preprocessor_choice.py
+++ b/test/test_pipeline/components/preprocessing/test_feature_preprocessor_choice.py
@@ -2,7 +2,7 @@ import copy
 import unittest
 
 from autoPyTorch.pipeline.components.preprocessing.tabular_preprocessing.feature_preprocessing. \
-    base_feature_preprocessor_choice import FeatureProprocessorChoice
+    base_feature_preprocessor_choice import FeaturePreprocessorChoice
 
 
 class TestFeaturePreprocessorChoice(unittest.TestCase):
@@ -10,13 +10,13 @@ class TestFeaturePreprocessorChoice(unittest.TestCase):
         """Make sure that we can setup a valid choice in the feature preprocessor
         choice"""
         dataset_properties = {'numerical_columns': list(range(4)), 'categorical_columns': [5]}
-        feature_preprocessor_choice = FeatureProprocessorChoice(dataset_properties)
+        feature_preprocessor_choice = FeaturePreprocessorChoice(dataset_properties)
         cs = feature_preprocessor_choice.get_hyperparameter_search_space()
 
         # Make sure that all hyperparameters are part of the search space
         self.assertListEqual(
             sorted(cs.get_hyperparameter('__choice__').choices),
-            sorted(list(feature_preprocessor_choice.get_components().keys()))
+            sorted(list(FeaturePreprocessorChoice.get_components().keys()))
         )
 
         # Make sure we can properly set some random configs
@@ -29,7 +29,7 @@ class TestFeaturePreprocessorChoice(unittest.TestCase):
             feature_preprocessor_choice.set_hyperparameters(config)
 
             self.assertEqual(feature_preprocessor_choice.choice.__class__,
-                             feature_preprocessor_choice.get_components()[config_dict['__choice__']])
+                             FeaturePreprocessorChoice.get_components()[config_dict['__choice__']])
 
             # Then check the choice configuration
             selected_choice = config_dict.pop('__choice__', None)
@@ -43,7 +43,7 @@ class TestFeaturePreprocessorChoice(unittest.TestCase):
     def test_only_categorical(self):
         dataset_properties = {'numerical_columns': [], 'categorical_columns': list(range(4))}
 
-        chooser = FeatureProprocessorChoice(dataset_properties)
+        chooser = FeaturePreprocessorChoice(dataset_properties)
         configspace = chooser.get_hyperparameter_search_space().sample_configuration().get_dictionary()
         self.assertEqual(configspace['__choice__'], 'NoFeaturePreprocessor')
 

--- a/test/test_pipeline/components/preprocessing/test_normalizer_choice.py
+++ b/test/test_pipeline/components/preprocessing/test_normalizer_choice.py
@@ -18,7 +18,7 @@ class TestNormalizerChoice(unittest.TestCase):
         # Make sure that all hyperparameters are part of the search space
         self.assertListEqual(
             sorted(cs.get_hyperparameter('__choice__').choices),
-            sorted(list(normalizer_choice.get_components().keys()))
+            sorted(list(NormalizerChoice.get_components().keys()))
         )
 
         # Make sure we can properly set some random configs
@@ -31,7 +31,7 @@ class TestNormalizerChoice(unittest.TestCase):
             normalizer_choice.set_hyperparameters(config)
 
             self.assertEqual(normalizer_choice.choice.__class__,
-                             normalizer_choice.get_components()[config_dict['__choice__']])
+                             NormalizerChoice.get_components()[config_dict['__choice__']])
 
             # Then check the choice configuration
             selected_choice = config_dict.pop('__choice__', None)

--- a/test/test_pipeline/components/preprocessing/test_scaler_choice.py
+++ b/test/test_pipeline/components/preprocessing/test_scaler_choice.py
@@ -18,7 +18,7 @@ class TestRescalerChoice(unittest.TestCase):
         # Make sure that all hyperparameters are part of the search space
         self.assertListEqual(
             sorted(cs.get_hyperparameter('__choice__').choices),
-            sorted(list(rescaler_choice.get_components().keys()))
+            sorted(list(ScalerChoice.get_components().keys()))
         )
 
         # Make sure we can properly set some random configs
@@ -31,7 +31,7 @@ class TestRescalerChoice(unittest.TestCase):
             rescaler_choice.set_hyperparameters(config)
 
             self.assertEqual(rescaler_choice.choice.__class__,
-                             rescaler_choice.get_components()[config_dict['__choice__']])
+                             ScalerChoice.get_components()[config_dict['__choice__']])
 
             # Then check the choice configuration
             selected_choice = config_dict.pop('__choice__', None)

--- a/test/test_pipeline/components/setup/test_setup.py
+++ b/test/test_pipeline/components/setup/test_setup.py
@@ -10,20 +10,14 @@ from sklearn.base import clone
 import torch
 from torch import nn
 
-import autoPyTorch.pipeline.components.setup.lr_scheduler.base_scheduler_choice as lr_components
-import \
-    autoPyTorch.pipeline.components.setup.network_initializer.base_network_init_choice as network_initializer_components  # noqa: E501
-import autoPyTorch.pipeline.components.setup.optimizer.base_optimizer_choice as optimizer_components
 from autoPyTorch import constants
 from autoPyTorch.pipeline.components.base_component import ThirdPartyComponents
 from autoPyTorch.pipeline.components.setup.lr_scheduler.base_scheduler_choice import (
     BaseLRComponent,
     SchedulerChoice
 )
-from autoPyTorch.pipeline.components.setup.network_backbone import base_network_backbone_choice
 from autoPyTorch.pipeline.components.setup.network_backbone.base_network_backbone import NetworkBackboneComponent
 from autoPyTorch.pipeline.components.setup.network_backbone.base_network_backbone_choice import NetworkBackboneChoice
-from autoPyTorch.pipeline.components.setup.network_head import base_network_head_choice
 from autoPyTorch.pipeline.components.setup.network_head.base_network_head import NetworkHeadComponent
 from autoPyTorch.pipeline.components.setup.network_head.base_network_head_choice import NetworkHeadChoice
 from autoPyTorch.pipeline.components.setup.network_initializer.base_network_init_choice import (
@@ -128,16 +122,15 @@ class TestScheduler:
         This also test that we can properly initialize each one
         of them
         """
-        scheduler_choice = SchedulerChoice(dataset_properties={})
 
         # Make sure all components are returned
-        assert len(scheduler_choice.get_components().keys()) == 7
+        assert len(SchedulerChoice.get_components().keys()) == 7
 
         # For every scheduler in the components, make sure
         # that it complies with the scikit learn estimator.
         # This is important because usually components are forked to workers,
         # so the set/get params methods should recreate the same object
-        for name, scheduler in scheduler_choice.get_components().items():
+        for name, scheduler in SchedulerChoice.get_components().items():
             config = scheduler.get_hyperparameter_search_space().sample_configuration()
             estimator = scheduler(**config)
             estimator_clone = clone(estimator)
@@ -168,7 +161,7 @@ class TestScheduler:
 
         # Make sure that all hyperparameters are part of the serach space
         assert sorted(cs.get_hyperparameter('__choice__').choices) == \
-               sorted(list(scheduler_choice.get_components().keys()))
+               sorted(list(SchedulerChoice.get_components().keys()))
 
         # Make sure we can properly set some random configs
         # Whereas just one iteration will make sure the algorithm works,
@@ -180,7 +173,7 @@ class TestScheduler:
             scheduler_choice.set_hyperparameters(config)
 
             assert scheduler_choice.choice.__class__ == \
-                   scheduler_choice.get_components()[config_dict['__choice__']]
+                   SchedulerChoice.get_components()[config_dict['__choice__']]
 
             # Then check the choice configuration
             selected_choice = config_dict.pop('__choice__', None)
@@ -194,11 +187,11 @@ class TestScheduler:
     def test_scheduler_add(self):
         """Makes sure that a component can be added to the CS"""
         # No third party components to start with
-        assert len(lr_components._addons.components) == 0
+        assert len(SchedulerChoice._addons.components) == 0
 
         # Then make sure the scheduler can be added and query'ed
-        lr_components.add_scheduler(DummyLR)
-        assert len(lr_components._addons.components) == 1
+        SchedulerChoice.add_scheduler(DummyLR)
+        assert len(SchedulerChoice._addons.components) == 1
         cs = SchedulerChoice(dataset_properties={}).get_hyperparameter_search_space()
         assert 'DummyLR' in str(cs)
 
@@ -212,16 +205,15 @@ class OptimizerTest:
         This also test that we can properly initialize each one
         of them
         """
-        optimizer_choice = OptimizerChoice(dataset_properties={})
 
         # Make sure all components are returned
-        assert len(optimizer_choice.get_components().keys()) == 4
+        assert len(OptimizerChoice.get_components().keys()) == 4
 
         # For every optimizer in the components, make sure
         # that it complies with the scikit learn estimator.
         # This is important because usually components are forked to workers,
         # so the set/get params methods should recreate the same object
-        for name, optimizer in optimizer_choice.get_components().items():
+        for name, optimizer in OptimizerChoice.get_components().items():
             config = optimizer.get_hyperparameter_search_space().sample_configuration()
             estimator = optimizer(**config)
             estimator_clone = clone(estimator)
@@ -252,7 +244,7 @@ class OptimizerTest:
 
         # Make sure that all hyperparameters are part of the serach space
         assert sorted(cs.get_hyperparameter('__choice__').choices) == \
-               sorted(list(optimizer_choice.get_components().keys()))
+               sorted(list(OptimizerChoice.get_components().keys()))
 
         # Make sure we can properly set some random configs
         # Whereas just one iteration will make sure the algorithm works,
@@ -263,7 +255,7 @@ class OptimizerTest:
             config_dict = copy.deepcopy(config.get_dictionary())
             optimizer_choice.set_hyperparameters(config)
 
-            assert optimizer_choice.choice.__class__ == optimizer_choice.get_components()[config_dict['__choice__']]
+            assert optimizer_choice.choice.__class__ == OptimizerChoice.get_components()[config_dict['__choice__']]
 
             # Then check the choice configuration
             selected_choice = config_dict.pop('__choice__', None)
@@ -277,20 +269,19 @@ class OptimizerTest:
     def test_optimizer_add(self):
         """Makes sure that a component can be added to the CS"""
         # No third party components to start with
-        assert len(optimizer_components._addons.components) == 0
+        assert len(OptimizerChoice._addons.components) == 0
 
         # Then make sure the optimizer can be added and query'ed
-        optimizer_components.add_optimizer(DummyOptimizer)
-        assert len(optimizer_components._addons.components) == 1
+        OptimizerChoice.add_optimizer(DummyOptimizer)
+        assert len(OptimizerChoice._addons.components) == 1
         cs = OptimizerChoice(dataset_properties={}).get_hyperparameter_search_space()
         assert 'DummyOptimizer' in str(cs)
 
 
 class TestNetworkBackbone:
     def test_all_backbones_available(self):
-        backbone_choice = NetworkBackboneChoice(dataset_properties={})
 
-        assert len(backbone_choice.get_components().keys()) == 8
+        assert len(NetworkBackboneChoice.get_components().keys()) == 8
 
     @pytest.mark.parametrize('task_type_input_shape', [(constants.IMAGE_CLASSIFICATION, (3, 64, 64)),
                                                        (constants.IMAGE_REGRESSION, (3, 64, 64)),
@@ -341,11 +332,10 @@ class TestNetworkBackbone:
             loss.backward()
 
     def test_every_backbone_is_valid(self):
-        backbone_choice = NetworkBackboneChoice(dataset_properties={})
 
-        assert len(backbone_choice.get_components().keys()) == 8
+        assert len(NetworkBackboneChoice.get_components().keys()) == 8
 
-        for name, backbone in backbone_choice.get_components().items():
+        for name, backbone in NetworkBackboneChoice.get_components().items():
             config = backbone.get_hyperparameter_search_space().sample_configuration()
             estimator = backbone(**config)
             estimator_clone = clone(estimator)
@@ -387,7 +377,7 @@ class TestNetworkBackbone:
                 network_backbone_choice.set_hyperparameters(config)
 
                 assert network_backbone_choice.choice.__class__ == \
-                       network_backbone_choice.get_components()[config_dict['__choice__']]
+                       NetworkBackboneChoice.get_components()[config_dict['__choice__']]
 
                 # Then check the choice configuration
                 selected_choice = config_dict.pop('__choice__', None)
@@ -405,25 +395,24 @@ class TestNetworkBackbone:
     def test_add_network_backbone(self):
         """Makes sure that a component can be added to the CS"""
         # No third party components to start with
-        assert len(base_network_backbone_choice._addons.components) == 0
+        assert len(NetworkBackboneChoice._addons.components) == 0
 
         # Then make sure the backbone can be added
-        base_network_backbone_choice.add_backbone(DummyBackbone)
-        assert len(base_network_backbone_choice._addons.components) == 1
+        NetworkBackboneChoice.add_backbone(DummyBackbone)
+        assert len(NetworkBackboneChoice._addons.components) == 1
 
         cs = NetworkBackboneChoice(dataset_properties={}). \
             get_hyperparameter_search_space(dataset_properties={"task_type": "tabular_classification"})
         assert "DummyBackbone" in str(cs)
 
         # clear addons
-        base_network_backbone_choice._addons = ThirdPartyComponents(NetworkBackboneComponent)
+        NetworkBackboneChoice._addons = ThirdPartyComponents(NetworkBackboneComponent)
 
 
 class TestNetworkHead:
     def test_all_heads_available(self):
-        network_head_choice = NetworkHeadChoice(dataset_properties={})
 
-        assert len(network_head_choice.get_components().keys()) == 2
+        assert len(NetworkHeadChoice.get_components().keys()) == 2
 
     @pytest.mark.parametrize('task_type_input_output_shape', [(constants.IMAGE_CLASSIFICATION, (3, 64, 64), (5,)),
                                                               (constants.IMAGE_REGRESSION, (3, 64, 64), (1,)),
@@ -464,13 +453,12 @@ class TestNetworkHead:
         This also test that we can properly initialize each one
         of them
         """
-        network_head_choice = NetworkHeadChoice(dataset_properties={'task_type': 'tabular_classification'})
 
         # For every network in the components, make sure
         # that it complies with the scikit learn estimator.
         # This is important because usually components are forked to workers,
         # so the set/get params methods should recreate the same object
-        for name, network_head in network_head_choice.get_components().items():
+        for name, network_head in NetworkHeadChoice.get_components().items():
             config = network_head.get_hyperparameter_search_space().sample_configuration()
             estimator = network_head(**config)
             estimator_clone = clone(estimator)
@@ -512,7 +500,7 @@ class TestNetworkHead:
                 network_head_choice.set_hyperparameters(config)
 
                 assert network_head_choice.choice.__class__ == \
-                       network_head_choice.get_components()[config_dict['__choice__']]
+                       NetworkHeadChoice.get_components()[config_dict['__choice__']]
 
                 # Then check the choice configuration
                 selected_choice = config_dict.pop('__choice__', None)
@@ -530,18 +518,18 @@ class TestNetworkHead:
     def test_add_network_head(self):
         """Makes sure that a component can be added to the CS"""
         # No third party components to start with
-        assert len(base_network_head_choice._addons.components) == 0
+        assert len(NetworkHeadChoice._addons.components) == 0
 
         # Then make sure the head can be added
-        base_network_head_choice.add_head(DummyHead)
-        assert len(base_network_head_choice._addons.components) == 1
+        NetworkHeadChoice.add_head(DummyHead)
+        assert len(NetworkHeadChoice._addons.components) == 1
 
         cs = NetworkHeadChoice(dataset_properties={}). \
             get_hyperparameter_search_space(dataset_properties={"task_type": "tabular_classification"})
         assert "DummyHead" in str(cs)
 
         # clear addons
-        base_network_head_choice._addons = ThirdPartyComponents(NetworkHeadComponent)
+        NetworkHeadChoice._addons = ThirdPartyComponents(NetworkHeadComponent)
 
 
 class TestNetworkInitializer:
@@ -553,16 +541,15 @@ class TestNetworkInitializer:
         This also test that we can properly initialize each one
         of them
         """
-        network_initializer_choice = NetworkInitializerChoice(dataset_properties={})
 
         # Make sure all components are returned
-        assert len(network_initializer_choice.get_components().keys()) == 5
+        assert len(NetworkInitializerChoice.get_components().keys()) == 5
 
         # For every optimizer in the components, make sure
         # that it complies with the scikit learn estimator.
         # This is important because usually components are forked to workers,
         # so the set/get params methods should recreate the same object
-        for name, network_initializer in network_initializer_choice.get_components().items():
+        for name, network_initializer in NetworkInitializerChoice.get_components().items():
             config = network_initializer.get_hyperparameter_search_space().sample_configuration()
             estimator = network_initializer(**config)
             estimator_clone = clone(estimator)
@@ -593,7 +580,7 @@ class TestNetworkInitializer:
 
         # Make sure that all hyperparameters are part of the serach space
         assert sorted(cs.get_hyperparameter('__choice__').choices) == \
-               sorted(list(network_initializer_choice.get_components().keys()))
+               sorted(list(NetworkInitializerChoice.get_components().keys()))
 
         # Make sure we can properly set some random configs
         # Whereas just one iteration will make sure the algorithm works,
@@ -605,7 +592,7 @@ class TestNetworkInitializer:
             network_initializer_choice.set_hyperparameters(config)
 
             assert network_initializer_choice.choice.__class__ == \
-                   network_initializer_choice.get_components()[config_dict['__choice__']]
+                   NetworkInitializerChoice.get_components()[config_dict['__choice__']]
 
             # Then check the choice configuration
             selected_choice = config_dict.pop('__choice__', None)
@@ -619,10 +606,10 @@ class TestNetworkInitializer:
     def test_network_initializer_add(self):
         """Makes sure that a component can be added to the CS"""
         # No third party components to start with
-        assert len(network_initializer_components._addons.components) == 0
+        assert len(NetworkInitializerChoice._addons.components) == 0
 
         # Then make sure the network_initializer can be added and query'ed
-        network_initializer_components.add_network_initializer(DummyNetworkInitializer)
-        assert len(network_initializer_components._addons.components) == 1
+        NetworkInitializerChoice.add_network_initializer(DummyNetworkInitializer)
+        assert len(NetworkInitializerChoice._addons.components) == 1
         cs = NetworkInitializerChoice(dataset_properties={}).get_hyperparameter_search_space()
         assert 'DummyNetworkInitializer' in str(cs)

--- a/test/test_pipeline/components/setup/test_setup_traditional_classification.py
+++ b/test/test_pipeline/components/setup/test_setup_traditional_classification.py
@@ -58,7 +58,7 @@ class TestModelChoice:
         cs = model_choice.get_hyperparameter_search_space(dataset_properties=dataset_properties)
 
         # Make sure that all hyperparameters are part of the search space
-        assert sorted(cs.get_hyperparameter('__choice__').choices) == sorted(list(model_choice.get_components().keys()))
+        assert sorted(cs.get_hyperparameter('__choice__').choices) == sorted(list(ModelChoice.get_components().keys()))
 
         # Make sure we can properly set some random configs
         # Whereas just one iteration will make sure the algorithm works,
@@ -69,7 +69,7 @@ class TestModelChoice:
             config_dict = copy.deepcopy(config.get_dictionary())
             model_choice.set_hyperparameters(config)
 
-            assert model_choice.choice.__class__ == model_choice.get_components()[config_dict['__choice__']]
+            assert model_choice.choice.__class__ == ModelChoice.get_components()[config_dict['__choice__']]
 
             # Then check the choice configuration
             selected_choice = config_dict.pop('__choice__', None)

--- a/test/test_pipeline/components/training/test_training.py
+++ b/test/test_pipeline/components/training/test_training.py
@@ -232,16 +232,15 @@ class TrainerTest(unittest.TestCase):
         This also test that we can properly initialize each one
         of them
         """
-        trainer_choice = TrainerChoice(dataset_properties={})
 
         # Make sure all components are returned
-        self.assertEqual(len(trainer_choice.get_components().keys()), 2)
+        self.assertEqual(len(TrainerChoice.get_components().keys()), 2)
 
         # For every optimizer in the components, make sure
         # that it complies with the scikit learn estimator.
         # This is important because usually components are forked to workers,
         # so the set/get params methods should recreate the same object
-        for name, trainer in trainer_choice.get_components().items():
+        for name, trainer in TrainerChoice.get_components().items():
             config = trainer.get_hyperparameter_search_space().sample_configuration()
             estimator = trainer(**config)
             estimator_clone = clone(estimator)
@@ -273,7 +272,7 @@ class TrainerTest(unittest.TestCase):
         # Make sure that all hyperparameters are part of the serach space
         self.assertListEqual(
             sorted(cs.get_hyperparameter('__choice__').choices),
-            sorted(list(trainer_choice.get_components().keys()))
+            sorted(list(TrainerChoice.get_components().keys()))
         )
 
         # Make sure we can properly set some random configs
@@ -286,7 +285,7 @@ class TrainerTest(unittest.TestCase):
             trainer_choice.set_hyperparameters(config)
 
             self.assertEqual(trainer_choice.choice.__class__,
-                             trainer_choice.get_components()[config_dict['__choice__']])
+                             TrainerChoice.get_components()[config_dict['__choice__']])
 
             # Then check the choice configuration
             selected_choice = config_dict.pop('__choice__', None)

--- a/test/test_pipeline/test_pipeline.py
+++ b/test/test_pipeline/test_pipeline.py
@@ -28,7 +28,8 @@ class DummyComponent(autoPyTorchComponent):
 
 
 class DummyChoice(autoPyTorchChoice):
-    def get_components(self):
+    @classmethod
+    def get_components(cls):
         return {
             'DummyComponent2': DummyComponent,
             'DummyComponent3': DummyComponent,


### PR DESCRIPTION
ToDo

- [x] Make `get_components` and `add_<something>` classmethods
- [ ] Rename each component to `components`
- [ ] Make `get_components` and `add_<something>` classmethods of `autoPyTorchChoice`