### PR TITLE
Fix bugs in cutout training

### DIFF
--- a/autoPyTorch/pipeline/components/training/trainer/RowCutMixTrainer.py
+++ b/autoPyTorch/pipeline/components/training/trainer/RowCutMixTrainer.py
@@ -39,7 +39,8 @@ class RowCutMixTrainer(MixUp, BaseTrainerComponent):
         # It is unlikely that the batch size is lower than the number of features, but
         # be safe
         size = min(X.shape[0], X.shape[1])
-        indices = torch.tensor(self.random_state.choice(range(1, size), max(1, np.int(size * lam))))
+        indices = torch.tensor(self.random_state.choice(range(1, size), max(1, np.int32(size * lam)),
+                                                        replace=False))
 
         X[:, indices] = X[index, :][:, indices]
 

--- a/autoPyTorch/pipeline/components/training/trainer/RowCutMixTrainer.py
+++ b/autoPyTorch/pipeline/components/training/trainer/RowCutMixTrainer.py
@@ -35,10 +35,7 @@ class RowCutMixTrainer(MixUp, BaseTrainerComponent):
         if beta <= 0 or r > self.alpha:
             return X, {'y_a': y, 'y_b': y[index], 'lam': 1}
 
-        # The mixup component mixes up also on the batch dimension
-        # It is unlikely that the batch size is lower than the number of features, but
-        # be safe
-        size = min(X.shape[0], X.shape[1])
+        size = X.shape[1]
         indices = torch.tensor(self.random_state.choice(range(1, size), max(1, np.int32(size * lam)),
                                                         replace=False))
 

--- a/autoPyTorch/pipeline/components/training/trainer/base_trainer.py
+++ b/autoPyTorch/pipeline/components/training/trainer/base_trainer.py
@@ -233,7 +233,8 @@ class BaseTrainerComponent(autoPyTorchTrainingComponent):
         metrics_during_training: bool,
         scheduler: _LRScheduler,
         task_type: int,
-        labels: Union[np.ndarray, torch.Tensor, pd.DataFrame]
+        labels: Union[np.ndarray, torch.Tensor, pd.DataFrame],
+        numerical_columns: Optional[List[int]] = None
     ) -> None:
 
         # Save the device to be used
@@ -288,6 +289,9 @@ class BaseTrainerComponent(autoPyTorchTrainingComponent):
 
         # task type (used for calculating metrics)
         self.task_type = task_type
+
+        # for cutout trainer, we need the list of numerical columns
+        self.numerical_columns = numerical_columns
 
     def on_epoch_start(self, X: Dict[str, Any], epoch: int) -> None:
         """

--- a/autoPyTorch/pipeline/components/training/trainer/base_trainer_choice.py
+++ b/autoPyTorch/pipeline/components/training/trainer/base_trainer_choice.py
@@ -336,7 +336,9 @@ class TrainerChoice(autoPyTorchChoice):
             metrics_during_training=X['metrics_during_training'],
             scheduler=X['lr_scheduler'],
             task_type=STRING_TO_TASK_TYPES[X['dataset_properties']['task_type']],
-            labels=X['y_train'][X['backend'].load_datamanager().splits[X['split_id']][0]]
+            labels=X['y_train'][X['backend'].load_datamanager().splits[X['split_id']][0]],
+            numerical_columns=X['dataset_properties']['numerical_columns'] if 'numerical_columns' in X[
+                'dataset_properties'] else None
         )
         total_parameter_count, trainable_parameter_count = self.count_parameters(X['network'])
         self.run_summary = RunSummary(


### PR DESCRIPTION
This PR fixes the following bugs:

1. we were not sampling the indices with replacement.
2. we were taking the minimum between batch size and num features, which is not necessary
3. Numerical features were getting -1 to them, whereas 0 makes more sense