### PR TITLE
[doc] Add the bug fix information for ipython user

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ python setup.py install
 
 ```
 
+NOTE: If you would like to use `ipython`, you need to run `unset _CONDA_PYTHON_SYSCONFIGDATA_NAME` after all the installation.
+
 ## Contributing
 
 If you want to contribute to Auto-PyTorch, clone the repository and checkout our current development branch

--- a/README.md
+++ b/README.md
@@ -27,17 +27,11 @@ git submodule update --init --recursive
 # Create the environment
 conda create -n autopytorch python=3.8
 conda activate autopytorch
-For Linux:
-    conda install gxx_linux-64 gcc_linux-64 swig
-For mac:
-    conda install -c conda-forge clang_osx-64 clangxx_osx-64
-    conda install -c anaconda swig
+conda install swig
 cat requirements.txt | xargs -n 1 -L 1 pip install
 python setup.py install
 
 ```
-
-NOTE: If you would like to use `ipython`, you need to run `unset _CONDA_PYTHON_SYSCONFIGDATA_NAME` after all the installation.
 
 ## Contributing
 


### PR DESCRIPTION
After the installation by following README, we will get an unwanted error regarding `ipython`.
Basically, we will not be able to use ipython by NoModuleFoundError at all, because we change the base conda setting. 

The command that yields the error is `conda install gxx_linux-64 gcc_linux-64 swig` and this can be fixed by `unset _CONDA_PYTHON_SYSCONFIGDATA_NAME`.
The unset command unsets the environment variable. 

You can reproduce this issue by the followings:
```
$ conda install gxx_linux-64 gcc_linux-64 swig
$ conda activate <Any environments>
$ which ipython
# Check the ipython refers to one of the conda environments
$ ipython
# This yields an error
 
$ unset _CONDA_PYTHON_SYSCONFIGDATA_NAME
# This environment variable is originally None, so we need to reset it
# ==> it fixes the issue.
```