### PR TITLE
[fix] Fix submodule-not-found issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
 import setuptools
 import sys
+
+
 if sys.version_info < (3, 7):
     raise ValueError(
-        'Unsupported Python version %d.%d.%d found. Auto-PyTorch requires Python '
-        '3.7 or higher.' % (sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
+        'Auto-Pytorch requires Python 3.7 or higher, but found version {}.{}.{}'.format(
+            sys.version_info.major, sys.version_info.minor, sys.version_info.micro
+        )
     )
 
 with open("README.md", "r") as f:
@@ -13,6 +16,16 @@ requirements = []
 with open("requirements.txt", "r") as f:
     for line in f:
         requirements.append(line.strip())
+
+
+requirements.append(
+    "automl_common "
+    "@ git+ssh://git@"
+    "github.com/automl/automl_common"
+    # "@v0.0.1#egg=automl_common"
+    "#egg=automl_common"
+)
+
 
 # noinspection PyInterpreter
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ with open("requirements.txt", "r") as f:
 
 requirements.append(
     "automl_common "
-    "@ git+ssh://git@"
+    # "@ git+ssh://git@"
+    "@ git+https://"
     "github.com/automl/automl_common"
     # "@v0.0.1#egg=automl_common"
     "#egg=automl_common"


### PR DESCRIPTION
Since the previous version did not include the submodule package via pip install, we could not run the auto pytorch without manually including `automl_common`.
I addressed this issue in this PR.

**NOTE**
This PR keeps yielding test failure as long as [This PR](https://github.com/automl/automl_common/pull/9) in automl_common is not merged.