### PR TITLE
[feat] Update automl_common and add setup.py for submodule

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,6 @@ with open("requirements.txt", "r") as f:
         requirements.append(line.strip())
 
 
-requirements.append(
-    "https://github.com/automl/automl_common.git"
-    "/tarball/autoPyTorch#egg=package-0.0.1"
-)
-
-
 # noinspection PyInterpreter
 setuptools.setup(
     name="autoPyTorch",
@@ -81,5 +75,6 @@ setuptools.setup(
     },
     test_suite="pytest",
     data_files=[('configs', ['autoPyTorch/configs/default_pipeline_options.json']),
-                ('portfolio', ['autoPyTorch/configs/greedy_portfolio.json'])]
+                ('portfolio', ['autoPyTorch/configs/greedy_portfolio.json'])],
+    dependency_links=['https://github.com/automl/automl_common.git/tarball/autoPyTorch#egg=package-0.0.1']
 )

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ with open("requirements.txt", "r") as f:
         requirements.append(line.strip())
 
 
+"""
 requirements.append(
     "automl_common "
     "@ git+ssh://git@"
@@ -25,6 +26,7 @@ requirements.append(
     # "@v0.0.1#egg=automl_common"
     "#egg=automl_common"
 )
+"""
 
 
 # noinspection PyInterpreter

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
 import setuptools
 import sys
+
+
 if sys.version_info < (3, 7):
     raise ValueError(
-        'Unsupported Python version %d.%d.%d found. Auto-PyTorch requires Python '
-        '3.7 or higher.' % (sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
+        'Auto-Pytorch requires Python 3.7 or higher, but found version {}.{}.{}'.format(
+            sys.version_info.major, sys.version_info.minor, sys.version_info.micro
+        )
     )
 
 with open("README.md", "r") as f:
@@ -13,6 +16,16 @@ requirements = []
 with open("requirements.txt", "r") as f:
     for line in f:
         requirements.append(line.strip())
+
+
+requirements.append(
+    "automl_common "
+    "@ git+ssh://git@"
+    "github.com/automl/automl_common"
+    # "@v0.0.1#egg=automl_common"
+    "#egg=automl_common"
+)
+
 
 # noinspection PyInterpreter
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,10 @@ with open("requirements.txt", "r") as f:
         requirements.append(line.strip())
 
 
-"""
 requirements.append(
-    "automl_common "
-    "@ git+ssh://git@"
-    "github.com/automl/automl_common"
-    # "@v0.0.1#egg=automl_common"
-    "#egg=automl_common"
+    "https://github.com/automl/automl_common.git"
+    "/tarball/autoPyTorch#egg=package-0.0.1"
 )
-"""
 
 
 # noinspection PyInterpreter


### PR DESCRIPTION
Since the previous version did not include the submodule package via pip install, we could not run the auto pytorch without manually including `automl_common`.
I addressed this issue in this PR.

**NOTE**
This PR keeps yielding test failure as long as [This PR](https://github.com/automl/automl_common/pull/9) in automl_common is not merged.