### PR TITLE
Fix 361

### DIFF
--- a/autoPyTorch/pipeline/components/training/trainer/__init__.py
+++ b/autoPyTorch/pipeline/components/training/trainer/__init__.py
@@ -298,7 +298,7 @@ class TrainerChoice(autoPyTorchChoice):
                 if self.budget_tracker.is_max_time_reached():
                     break
                 else:
-                    raise RuntimeError("`train_loss` computed to None.")
+                    raise RuntimeError("Got an unexpected None in `train_loss`.")
 
             val_loss, val_metrics, test_loss, test_metrics = None, {}, None, {}
             if self.eval_valid_each_epoch(X):
@@ -340,6 +340,9 @@ class TrainerChoice(autoPyTorchChoice):
 
             if 'cuda' in X['device']:
                 torch.cuda.empty_cache()
+
+        if self.run_summary.is_empty():
+            raise RuntimeError("Budget exhausted without finishing an epoch.")
 
         # wrap up -- add score if not evaluating every epoch
         if not self.eval_valid_each_epoch(X):

--- a/autoPyTorch/pipeline/components/training/trainer/__init__.py
+++ b/autoPyTorch/pipeline/components/training/trainer/__init__.py
@@ -293,6 +293,13 @@ class TrainerChoice(autoPyTorchChoice):
                 writer=writer,
             )
 
+            if train_loss is None:
+                if self.budget_tracker.is_max_time_reached():
+                    # train_loss is None, if epoch could not be started, usually due to `is_max_time_reached()``
+                    break
+                else:
+                    raise RuntimeError("`train_loss` computed to None.")
+
             val_loss, val_metrics, test_loss, test_metrics = None, {}, None, {}
             if self.eval_valid_each_epoch(X):
                 val_loss, val_metrics = self.choice.evaluate(X['val_data_loader'], epoch, writer)

--- a/autoPyTorch/pipeline/components/training/trainer/__init__.py
+++ b/autoPyTorch/pipeline/components/training/trainer/__init__.py
@@ -293,9 +293,9 @@ class TrainerChoice(autoPyTorchChoice):
                 writer=writer,
             )
 
+            # its fine if train_loss is None due to `is_max_time_reached()`
             if train_loss is None:
                 if self.budget_tracker.is_max_time_reached():
-                    # train_loss is None, if epoch could not be started, usually due to `is_max_time_reached()``
                     break
                 else:
                     raise RuntimeError("`train_loss` computed to None.")

--- a/autoPyTorch/pipeline/components/training/trainer/base_trainer.py
+++ b/autoPyTorch/pipeline/components/training/trainer/base_trainer.py
@@ -179,6 +179,16 @@ class RunSummary(object):
         string += '=' * 40
         return string
 
+    def is_empty(self) -> bool:
+        """
+        Checks if the object is empty or not
+
+        Returns:
+            bool
+        """
+        # if train_loss is empty, we can be sure that RunSummary is empty.
+        return not bool(self.performance_tracker['train_loss'])
+
 
 class BaseTrainerComponent(autoPyTorchTrainingComponent):
 

--- a/autoPyTorch/pipeline/components/training/trainer/base_trainer.py
+++ b/autoPyTorch/pipeline/components/training/trainer/base_trainer.py
@@ -277,7 +277,7 @@ class BaseTrainerComponent(autoPyTorchTrainingComponent):
 
     def train_epoch(self, train_loader: torch.utils.data.DataLoader, epoch: int,
                     writer: Optional[SummaryWriter],
-                    ) -> Tuple[float, Dict[str, float]]:
+                    ) -> Tuple[Optional[float], Dict[str, float]]:
         """
         Train the model for a single epoch.
 
@@ -316,6 +316,9 @@ class BaseTrainerComponent(autoPyTorchTrainingComponent):
                     loss,
                     epoch * len(train_loader) + step,
                 )
+
+        if N == 0:
+            return None, {}
 
         self._scheduler_step(step_interval=StepIntervalUnit.epoch, loss=loss_sum / N)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

Note that a Pull Request should only contain one of refactoring, new features or documentation changes.
Please separate these changes and send us individual PRs for each.
For more information on how to create a good pull request, please refer to [The anatomy of a perfect pull request](https://medium.com/@hugooodias/the-anatomy-of-a-perfect-pull-request-567382bb6067).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
<!-- 
* [ ] Have you followed the guidelines in our Contributing document?
-->


## Description
<!--- Describe your changes in detail -->
Fixes issue #361 by returning `None` as the train_loss in case `is_max_runtime_reached()` before training a batch of an epoch.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#361 
