### PR TITLE
[fix] Change int to np.int32 for the ndarray dtype specification

### DIFF
--- a/autoPyTorch/pipeline/components/setup/network_embedding/base_network_embedding.py
+++ b/autoPyTorch/pipeline/components/setup/network_embedding/base_network_embedding.py
@@ -44,7 +44,7 @@ class NetworkEmbeddingComponent(autoPyTorchSetupComponent):
             num_numerical_columns = numerical_column_transformer.transform(
                 X_train[:, X['dataset_properties']['numerical_columns']]).shape[1]
         num_input_features = np.zeros((num_numerical_columns + len(X['dataset_properties']['categorical_columns'])),
-                                      dtype=int)
+                                      dtype=np.int32)
         categories = X['dataset_properties']['categories']
 
         for i, category in enumerate(categories):

--- a/autoPyTorch/pipeline/create_searchspace_util.py
+++ b/autoPyTorch/pipeline/create_searchspace_util.py
@@ -47,7 +47,7 @@ def get_match_array(
     matches_dimensions = [len(choices) for choices in node_i_choices]
     # Start by allowing every combination of nodes. Go through all
     # combinations/pipelines and erase the illegal ones
-    matches = np.ones(matches_dimensions, dtype=int)
+    matches = np.ones(matches_dimensions, dtype=np.int32)
 
     # TODO: Check if we need this, like are there combinations from the
     # pipeline we should dynamically avoid?


### PR DESCRIPTION
Just change int to np.int32 for the numpy array specification to remove unneeded warnings.