### PR TITLE
[feat] Add new task inference for APT

### DIFF
--- a/autoPyTorch/data/base_feature_validator.py
+++ b/autoPyTorch/data/base_feature_validator.py
@@ -12,7 +12,7 @@ from sklearn.base import BaseEstimator
 from autoPyTorch.utils.logging_ import PicklableClientLogger
 
 
-SUPPORTED_FEAT_TYPES = Union[
+SupportedFeatTypes = Union[
     List,
     pd.DataFrame,
     np.ndarray,
@@ -68,8 +68,8 @@ class BaseFeatureValidator(BaseEstimator):
 
     def fit(
         self,
-        X_train: SUPPORTED_FEAT_TYPES,
-        X_test: Optional[SUPPORTED_FEAT_TYPES] = None,
+        X_train: SupportedFeatTypes,
+        X_test: Optional[SupportedFeatTypes] = None,
     ) -> BaseEstimator:
         """
         Validates and fit a categorical encoder (if needed) to the features.
@@ -77,10 +77,10 @@ class BaseFeatureValidator(BaseEstimator):
         CSR sparse data types are also supported
 
         Args:
-            X_train (SUPPORTED_FEAT_TYPES):
+            X_train (SupportedFeatTypes):
                 A set of features that are going to be validated (type and dimensionality
                 checks) and a encoder fitted in the case the data needs encoding
-            X_test (Optional[SUPPORTED_FEAT_TYPES]):
+            X_test (Optional[SupportedFeatTypes]):
                 A hold out set of data used for checking
         """
 
@@ -109,11 +109,11 @@ class BaseFeatureValidator(BaseEstimator):
 
     def _fit(
         self,
-        X: SUPPORTED_FEAT_TYPES,
+        X: SupportedFeatTypes,
     ) -> BaseEstimator:
         """
         Args:
-            X (SUPPORTED_FEAT_TYPES):
+            X (SupportedFeatTypes):
                 A set of features that are going to be validated (type and dimensionality
                 checks) and a encoder fitted in the case the data needs encoding
         Returns:
@@ -124,11 +124,11 @@ class BaseFeatureValidator(BaseEstimator):
 
     def transform(
         self,
-        X: SUPPORTED_FEAT_TYPES,
+        X: SupportedFeatTypes,
     ) -> np.ndarray:
         """
         Args:
-            X_train (SUPPORTED_FEAT_TYPES):
+            X_train (SupportedFeatTypes):
                 A set of features, whose categorical features are going to be
                 transformed
 

--- a/autoPyTorch/data/base_feature_validator.py
+++ b/autoPyTorch/data/base_feature_validator.py
@@ -5,25 +5,13 @@ import numpy as np
 
 import pandas as pd
 
-import scipy.sparse
-
 from sklearn.base import BaseEstimator
 
+from autoPyTorch.utils.common import SparseMatrixType
 from autoPyTorch.utils.logging_ import PicklableClientLogger
 
 
-SupportedFeatTypes = Union[
-    List,
-    pd.DataFrame,
-    np.ndarray,
-    scipy.sparse.bsr_matrix,
-    scipy.sparse.coo_matrix,
-    scipy.sparse.csc_matrix,
-    scipy.sparse.csr_matrix,
-    scipy.sparse.dia_matrix,
-    scipy.sparse.dok_matrix,
-    scipy.sparse.lil_matrix,
-]
+SupportedFeatTypes = Union[List, pd.DataFrame, np.ndarray, SparseMatrixType]
 
 
 class BaseFeatureValidator(BaseEstimator):

--- a/autoPyTorch/data/base_target_validator.py
+++ b/autoPyTorch/data/base_target_validator.py
@@ -12,7 +12,7 @@ from sklearn.base import BaseEstimator
 from autoPyTorch.utils.logging_ import PicklableClientLogger
 
 
-SUPPORTED_TARGET_TYPES = Union[
+SupportedTargetTypes = Union[
     List,
     pd.Series,
     pd.DataFrame,
@@ -69,17 +69,17 @@ class BaseTargetValidator(BaseEstimator):
 
     def fit(
         self,
-        y_train: SUPPORTED_TARGET_TYPES,
-        y_test: Optional[SUPPORTED_TARGET_TYPES] = None,
+        y_train: SupportedTargetTypes,
+        y_test: Optional[SupportedTargetTypes] = None,
     ) -> BaseEstimator:
         """
         Validates and fit a categorical encoder (if needed) to the targets
         The supported data types are List, numpy arrays and pandas DataFrames.
 
         Args:
-            y_train (SUPPORTED_TARGET_TYPES)
+            y_train (SupportedTargetTypes)
                 A set of targets set aside for training
-            y_test (Union[SUPPORTED_TARGET_TYPES])
+            y_test (Union[SupportedTargetTypes])
                 A hold out set of data used of the targets. It is also used to fit the
                 categories of the encoder.
         """
@@ -128,26 +128,26 @@ class BaseTargetValidator(BaseEstimator):
 
     def _fit(
         self,
-        y_train: SUPPORTED_TARGET_TYPES,
-        y_test: Optional[SUPPORTED_TARGET_TYPES] = None,
+        y_train: SupportedTargetTypes,
+        y_test: Optional[SupportedTargetTypes] = None,
     ) -> BaseEstimator:
         """
         Args:
-            y_train (SUPPORTED_TARGET_TYPES)
+            y_train (SupportedTargetTypes)
                 The labels of the current task. They are going to be encoded in case
                 of classification
-            y_test (Optional[SUPPORTED_TARGET_TYPES])
+            y_test (Optional[SupportedTargetTypes])
                 A holdout set of labels
         """
         raise NotImplementedError()
 
     def transform(
         self,
-        y: Union[SUPPORTED_TARGET_TYPES],
+        y: Union[SupportedTargetTypes],
     ) -> np.ndarray:
         """
         Args:
-            y (SUPPORTED_TARGET_TYPES)
+            y (SupportedTargetTypes)
                 A set of targets that are going to be encoded if the current task
                 is classification
         Returns:
@@ -158,7 +158,7 @@ class BaseTargetValidator(BaseEstimator):
 
     def inverse_transform(
         self,
-        y: SUPPORTED_TARGET_TYPES,
+        y: SupportedTargetTypes,
     ) -> np.ndarray:
         """
         Revert any encoding transformation done on a target array

--- a/autoPyTorch/data/base_target_validator.py
+++ b/autoPyTorch/data/base_target_validator.py
@@ -5,26 +5,13 @@ import numpy as np
 
 import pandas as pd
 
-import scipy.sparse
-
 from sklearn.base import BaseEstimator
 
+from autoPyTorch.utils.common import SparseMatrixType
 from autoPyTorch.utils.logging_ import PicklableClientLogger
 
 
-SupportedTargetTypes = Union[
-    List,
-    pd.Series,
-    pd.DataFrame,
-    np.ndarray,
-    scipy.sparse.bsr_matrix,
-    scipy.sparse.coo_matrix,
-    scipy.sparse.csc_matrix,
-    scipy.sparse.csr_matrix,
-    scipy.sparse.dia_matrix,
-    scipy.sparse.dok_matrix,
-    scipy.sparse.lil_matrix,
-]
+SupportedTargetTypes = Union[List, pd.Series, pd.DataFrame, np.ndarray, SparseMatrixType]
 
 
 class BaseTargetValidator(BaseEstimator):

--- a/autoPyTorch/data/base_validator.py
+++ b/autoPyTorch/data/base_validator.py
@@ -7,8 +7,8 @@ import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.exceptions import NotFittedError
 
-from autoPyTorch.data.base_feature_validator import SUPPORTED_FEAT_TYPES
-from autoPyTorch.data.base_target_validator import SUPPORTED_TARGET_TYPES
+from autoPyTorch.data.base_feature_validator import SupportedFeatTypes
+from autoPyTorch.data.base_target_validator import SupportedTargetTypes
 
 
 class BaseInputValidator(BaseEstimator):
@@ -40,10 +40,10 @@ class BaseInputValidator(BaseEstimator):
 
     def fit(
         self,
-        X_train: SUPPORTED_FEAT_TYPES,
-        y_train: SUPPORTED_TARGET_TYPES,
-        X_test: Optional[SUPPORTED_FEAT_TYPES] = None,
-        y_test: Optional[SUPPORTED_TARGET_TYPES] = None,
+        X_train: SupportedFeatTypes,
+        y_train: SupportedTargetTypes,
+        X_test: Optional[SupportedFeatTypes] = None,
+        y_test: Optional[SupportedTargetTypes] = None,
     ) -> BaseEstimator:
         """
         Validates and fit a categorical encoder (if needed) to the features, and
@@ -59,15 +59,15 @@ class BaseInputValidator(BaseEstimator):
             + If performing a classification task, the data is going to be encoded
 
         Args:
-            X_train (SUPPORTED_FEAT_TYPES):
+            X_train (SupportedFeatTypes):
                 A set of features that are going to be validated (type and dimensionality
                 checks). If this data contains categorical columns, an encoder is going to
                 be instantiated and trained with this data.
-            y_train (SUPPORTED_TARGET_TYPES):
+            y_train (SupportedTargetTypes):
                 A set of targets that are going to be encoded if the task is for classification
-            X_test (Optional[SUPPORTED_FEAT_TYPES]):
+            X_test (Optional[SupportedFeatTypes]):
                 A hold out set of features used for checking
-            y_test (SUPPORTED_TARGET_TYPES):
+            y_test (SupportedTargetTypes):
                 A hold out set of targets used for checking. Additionally, if the current task
                 is a classification task, this y_test categories are also going to be used to
                 fit a pre-processing encoding (to prevent errors on unseen classes).
@@ -96,16 +96,16 @@ class BaseInputValidator(BaseEstimator):
 
     def transform(
         self,
-        X: SUPPORTED_FEAT_TYPES,
-        y: Optional[SUPPORTED_TARGET_TYPES] = None,
+        X: SupportedFeatTypes,
+        y: Optional[SupportedTargetTypes] = None,
     ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
         """
         Transform the given target or features to a numpy array
 
         Args:
-            X (SUPPORTED_FEAT_TYPES):
+            X (SupportedFeatTypes):
                 A set of features to transform
-            y (Optional[SUPPORTED_TARGET_TYPES]):
+            y (Optional[SupportedTargetTypes]):
                 A set of targets to transform
 
         Returns:

--- a/autoPyTorch/data/tabular_feature_validator.py
+++ b/autoPyTorch/data/tabular_feature_validator.py
@@ -16,7 +16,7 @@ from sklearn.exceptions import NotFittedError
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import make_pipeline
 
-from autoPyTorch.data.base_feature_validator import BaseFeatureValidator, SUPPORTED_FEAT_TYPES
+from autoPyTorch.data.base_feature_validator import BaseFeatureValidator, SupportedFeatTypes
 
 
 def _create_column_transformer(
@@ -117,7 +117,7 @@ class TabularFeatureValidator(BaseFeatureValidator):
 
     def _fit(
         self,
-        X: SUPPORTED_FEAT_TYPES,
+        X: SupportedFeatTypes,
     ) -> BaseEstimator:
         """
         In case input data is a pandas DataFrame, this utility encodes the user provided
@@ -125,7 +125,7 @@ class TabularFeatureValidator(BaseFeatureValidator):
         will be able to use
 
         Args:
-            X (SUPPORTED_FEAT_TYPES):
+            X (SupportedFeatTypes):
                 A set of features that are going to be validated (type and dimensionality
                 checks) and an encoder fitted in the case the data needs encoding
 
@@ -204,14 +204,14 @@ class TabularFeatureValidator(BaseFeatureValidator):
 
     def transform(
         self,
-        X: SUPPORTED_FEAT_TYPES,
+        X: SupportedFeatTypes,
     ) -> np.ndarray:
         """
         Validates and fit a categorical encoder (if needed) to the features.
         The supported data types are List, numpy arrays and pandas DataFrames.
 
         Args:
-            X_train (SUPPORTED_FEAT_TYPES):
+            X_train (SupportedFeatTypes):
                 A set of features, whose categorical features are going to be
                 transformed
 
@@ -276,13 +276,13 @@ class TabularFeatureValidator(BaseFeatureValidator):
 
     def _check_data(
         self,
-        X: SUPPORTED_FEAT_TYPES,
+        X: SupportedFeatTypes,
     ) -> None:
         """
         Feature dimensionality and data type checks
 
         Args:
-            X (SUPPORTED_FEAT_TYPES):
+            X (SupportedFeatTypes):
                 A set of features that are going to be validated (type and dimensionality
                 checks) and an encoder fitted in the case the data needs encoding
         """
@@ -429,8 +429,8 @@ class TabularFeatureValidator(BaseFeatureValidator):
 
     def list_to_dataframe(
         self,
-        X_train: SUPPORTED_FEAT_TYPES,
-        X_test: Optional[SUPPORTED_FEAT_TYPES] = None,
+        X_train: SupportedFeatTypes,
+        X_test: Optional[SupportedFeatTypes] = None,
     ) -> Tuple[pd.DataFrame, Optional[pd.DataFrame]]:
         """
         Converts a list to a pandas DataFrame. In this process, column types are inferred.
@@ -438,10 +438,10 @@ class TabularFeatureValidator(BaseFeatureValidator):
         If test data is provided, we proactively match it to train data
 
         Args:
-            X_train (SUPPORTED_FEAT_TYPES):
+            X_train (SupportedFeatTypes):
                 A set of features that are going to be validated (type and dimensionality
                 checks) and a encoder fitted in the case the data needs encoding
-            X_test (Optional[SUPPORTED_FEAT_TYPES]):
+            X_test (Optional[SupportedFeatTypes]):
                 A hold out set of data used for checking
 
         Returns:

--- a/autoPyTorch/data/tabular_target_validator.py
+++ b/autoPyTorch/data/tabular_target_validator.py
@@ -29,11 +29,11 @@ def _modify_regression_target(y: ArrayType) -> ArrayType:
     # Regression targets must have numbers after a decimal point.
     # Ref: https://github.com/scikit-learn/scikit-learn/issues/8952
     y_min = np.abs(y).min()
-    offset = y_min * 1e-16  # Sufficiently small number
-    if y_min > 1e15:
+    offset = max(y_min, 1e-13) * 1e-13  # Sufficiently small number
+    if y_min > 1e12:
         raise ValueError(
             "The minimum value for the target labels of regression tasks must be smaller than "
-            f"1e15 to avoid errors caused by an overflow, but got {y_min}"
+            f"1e12 to avoid errors caused by an overflow, but got {y_min}"
         )
 
     # Since it is all integer, we can just add a random small number

--- a/autoPyTorch/datasets/base_dataset.py
+++ b/autoPyTorch/datasets/base_dataset.py
@@ -69,7 +69,7 @@ def _get_output_properties(train_tensors: BaseDatasetInputType) -> Tuple[int, st
         target_labels = np.array(train_tensors[1])
 
     output_type: str = type_of_target(target_labels)
-    if STRING_TO_OUTPUT_TYPES.get(output_type, None) in CLASSIFICATION_OUTPUTS:
+    if STRING_TO_OUTPUT_TYPES[output_type] in CLASSIFICATION_OUTPUTS:
         output_dim = len(np.unique(target_labels))
     elif target_labels.ndim > 1:
         output_dim = target_labels.shape[-1]

--- a/autoPyTorch/utils/common.py
+++ b/autoPyTorch/utils/common.py
@@ -20,6 +20,15 @@ import torch
 from torch.utils.data.dataloader import default_collate
 
 HyperparameterValueType = Union[int, str, float]
+SparseMatrixType = Union[
+    scipy.sparse.bsr_matrix,
+    scipy.sparse.coo_matrix,
+    scipy.sparse.csc_matrix,
+    scipy.sparse.csr_matrix,
+    scipy.sparse.dia_matrix,
+    scipy.sparse.dok_matrix,
+    scipy.sparse.lil_matrix,
+]
 
 
 class FitRequirement(NamedTuple):

--- a/test/test_api/test_api.py
+++ b/test/test_api/test_api.py
@@ -912,10 +912,8 @@ def test_tabular_classification_test_evaluator(openml_id, backend, n_samples):
 )
 def test_task_inference(ans, task_class, backend):
     # Get the data and check that contents of data-manager make sense
-    X = np.random.random((5, 1))
-    y = np.array([0, 1, 2, 3, 4]) + 10 ** 15
-
-    X_train, _, y_train, _ = sklearn.model_selection.train_test_split(X, y, random_state=42)
+    X = np.random.random((6, 1))
+    y = np.array([-10 ** 12, 0, 1, 2, 3, 4], dtype=np.int64) + 10 ** 12
 
     estimator = task_class(
         backend=backend,
@@ -923,12 +921,12 @@ def test_task_inference(ans, task_class, backend):
         resampling_strategy_args=None,
         seed=42,
     )
-    dataset = estimator.get_dataset(X_train, y_train)
+    dataset = estimator.get_dataset(X, y)
     assert dataset.output_type == ans
 
-    y_train += 1
+    y += 10 ** 12 + 10  # Check if the function catches overflow possibilities
     if ans == 'continuous':
         with pytest.raises(ValueError):  # ValueError due to `Too large value`
-            estimator.get_dataset(X_train, y_train)
+            estimator.get_dataset(X, y)
     else:
-        estimator.get_dataset(X_train, y_train)
+        estimator.get_dataset(X, y)

--- a/test/test_data/test_target_validator.py
+++ b/test/test_data/test_target_validator.py
@@ -150,17 +150,17 @@ def test_targetvalidator_supported_types_noclassification(input_data_targettest)
     assert validator.encoder is None
 
     if hasattr(input_data_targettest, "iloc"):
-        np.testing.assert_array_equal(
+        assert np.allclose(
             np.ravel(input_data_targettest.to_numpy()),
             np.ravel(transformed_y)
         )
     elif sparse.issparse(input_data_targettest):
-        np.testing.assert_array_equal(
+        assert np.allclose(
             np.ravel(input_data_targettest.todense()),
             np.ravel(transformed_y.todense())
         )
     else:
-        np.testing.assert_array_equal(
+        assert np.allclose(
             np.ravel(np.array(input_data_targettest)),
             np.ravel(transformed_y)
         )

--- a/test/test_datasets/test_base_dataset.py
+++ b/test/test_datasets/test_base_dataset.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+import pytest
+
+from autoPyTorch.datasets.base_dataset import _get_output_properties
+
+
+@pytest.mark.parametrize(
+    "target_labels,dim,task_type", (
+        (np.arange(5), 5, "multiclass"),
+        (np.linspace(0, 1, 3), 1, "continuous"),
+        (np.linspace(0, 1, 3)[:, np.newaxis], 1, "continuous")
+    )
+)
+def test_get_output_properties(target_labels, dim, task_type):
+    train_tensors = np.array([np.empty_like(target_labels), target_labels])
+    output_dim, output_type = _get_output_properties(train_tensors)
+    assert output_dim == dim
+    assert output_type == task_type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

## Description
This is the hotfix for the [issue#352](https://github.com/automl/Auto-PyTorch/issues/352).
Since the inference of the task type in sklearn does not properly handle the continuous, I added a feature to filter continuous (i.e. regression task) from multiclass. 

## Motivation and Context
see [issue#352](https://github.com/automl/Auto-PyTorch/issues/352)..

## How has this been tested?
It is not tested by proper pytest, but I checked by the following locally.
Note that `data.csv` is available in [issue#352](https://github.com/automl/Auto-PyTorch/issues/352).

```python
from autoPyTorch.api.tabular_regression import TabularRegressionTask
import pandas as pd
from sklearn.model_selection import train_test_split


input = [
    "P1",
    "P5p1",
    "P6p2",
    "P11p4",
    "P14p9",
    "P15p1",
    "P15p3",
    "P16p2",
    "P18p2",
    "P27p4",
    "H2p2",
    "H8p2",
    "H10p1",
    "H13p1",
    "H18pA",
    "H40p4",
]
output = ["price"]

if __name__ == '__main__':
    # read dataframe
    df = pd.read_csv("data.csv")

    # split data
    X = df[input]
    y = df[output]
    X_train, X_test, y_train, y_test = train_test_split(
        X, y, train_size=0.8, random_state=1
    )

    # train model
    api = TabularRegressionTask(n_jobs=7)
    api.search(
        X_train=X_train,
        y_train=y_train,
        X_test=X_test.copy(),
        y_test=y_test.copy(),
        optimize_metric="r2",
        total_walltime_limit=120,
    )
```

Note that the original code yields the following error by the same code:
```
Traceback (most recent call last):
  File "bug_test.py", line 39, in <module>
    api.search(
  File "/home/Auto-PyTorch/autoPyTorch/api/tabular_regression.py", line 300, in search
    return self._search(
  File "/home/Auto-PyTorch/autoPyTorch/api/base_task.py", line 876, in _search
    raise ValueError("Incompatible dataset entered for current task,"
ValueError: Incompatible dataset entered for current task,expected dataset to have task type :tabular_regression got :tabular_classification
```