### PR TITLE
[feat] Add __str__ to autoPyTorchEnum

### DIFF
--- a/autoPyTorch/utils/common.py
+++ b/autoPyTorch/utils/common.py
@@ -101,6 +101,9 @@ class autoPyTorchEnum(str, Enum):
     def __hash__(self) -> int:
         return hash(self.value)
 
+    def __str__(self) -> str:
+        return str(self.value)
+
 
 def custom_collate_fn(batch: List) -> List[Optional[torch.Tensor]]:
     """


### PR DESCRIPTION
Since we need to call string by `enum.<something>.value`, I added `__str__` so that we can intuitively call it by `str(enum.<something>)`.