### PR TITLE
[ADD] Calculate memory of dataset after one hot encoding

### DIFF
--- a/autoPyTorch/api/base_task.py
+++ b/autoPyTorch/api/base_task.py
@@ -989,7 +989,7 @@ class BaseTask(ABC):
         load_models: bool = True,
         portfolio_selection: Optional[str] = None,
         dask_client: Optional[dask.distributed.Client] = None,
-        min_configs_search: int = 100
+        min_configs_search: int = 2
     ) -> 'BaseTask':
         """
         Search for the best pipeline configuration for the given dataset.

--- a/autoPyTorch/api/tabular_classification.py
+++ b/autoPyTorch/api/tabular_classification.py
@@ -255,6 +255,7 @@ class TabularClassificationTask(BaseTask):
         load_models: bool = True,
         portfolio_selection: Optional[str] = None,
         dataset_compression: Union[Mapping[str, Any], bool] = False,
+        min_configs_search: int = 100
     ) -> 'BaseTask':
         """
         Search for the best pipeline configuration for the given dataset.
@@ -454,6 +455,7 @@ class TabularClassificationTask(BaseTask):
             disable_file_output=disable_file_output,
             load_models=load_models,
             portfolio_selection=portfolio_selection,
+            min_configs_search=min_configs_search
         )
 
     def predict(

--- a/autoPyTorch/api/tabular_classification.py
+++ b/autoPyTorch/api/tabular_classification.py
@@ -255,7 +255,7 @@ class TabularClassificationTask(BaseTask):
         load_models: bool = True,
         portfolio_selection: Optional[str] = None,
         dataset_compression: Union[Mapping[str, Any], bool] = False,
-        min_configs_search: int = 100
+        min_configs_search: int = 2
     ) -> 'BaseTask':
         """
         Search for the best pipeline configuration for the given dataset.

--- a/autoPyTorch/api/tabular_regression.py
+++ b/autoPyTorch/api/tabular_regression.py
@@ -252,6 +252,7 @@ class TabularRegressionTask(BaseTask):
         load_models: bool = True,
         portfolio_selection: Optional[str] = None,
         dataset_compression: Union[Mapping[str, Any], bool] = False,
+        min_configs_search: int = 100
     ) -> 'BaseTask':
         """
         Search for the best pipeline configuration for the given dataset.
@@ -452,6 +453,7 @@ class TabularRegressionTask(BaseTask):
             disable_file_output=disable_file_output,
             load_models=load_models,
             portfolio_selection=portfolio_selection,
+            min_configs_search=min_configs_search
         )
 
     def predict(

--- a/autoPyTorch/api/tabular_regression.py
+++ b/autoPyTorch/api/tabular_regression.py
@@ -252,7 +252,7 @@ class TabularRegressionTask(BaseTask):
         load_models: bool = True,
         portfolio_selection: Optional[str] = None,
         dataset_compression: Union[Mapping[str, Any], bool] = False,
-        min_configs_search: int = 100
+        min_configs_search: int = 2
     ) -> 'BaseTask':
         """
         Search for the best pipeline configuration for the given dataset.

--- a/autoPyTorch/data/tabular_validator.py
+++ b/autoPyTorch/data/tabular_validator.py
@@ -104,6 +104,8 @@ class TabularInputValidator(BaseInputValidator):
                 y=y,
                 is_classification=self.is_classification,
                 random_state=self.seed,
+                categorical_columns=self.feature_validator.categorical_columns,
+                n_categories_per_cat_column=[len(cat) for cat in self.feature_validator.categories],
                 **self.dataset_compression  # type: ignore [arg-type]
             )
             self._reduced_dtype = dict(X.dtypes) if is_dataframe else X.dtype

--- a/autoPyTorch/evaluation/train_evaluator.py
+++ b/autoPyTorch/evaluation/train_evaluator.py
@@ -383,6 +383,7 @@ class TrainEvaluator(AbstractEvaluator):
              'val_indices': test_indices,
              'split_id': fold,
              'num_run': self.num_run,
+             'start_time': self.starttime,
              **self.fit_dictionary}  # fit dictionary
         y = None
         fit_and_suppress_warnings(self.logger, pipeline, X, y)
@@ -412,10 +413,10 @@ class TrainEvaluator(AbstractEvaluator):
 
         train_pred = self.predict_function(subsampler(self.X_train, train_indices), pipeline,
                                            self.y_train[train_indices])
-
+        self.logger.debug("finished predicting on train set in tae")
         opt_pred = self.predict_function(subsampler(self.X_train, test_indices), pipeline,
                                          self.y_train[train_indices])
-
+        self.logger.debug("finished predicting on opt set in tae")
         if self.X_valid is not None:
             valid_pred = self.predict_function(self.X_valid, pipeline,
                                                self.y_valid)
@@ -427,7 +428,7 @@ class TrainEvaluator(AbstractEvaluator):
                                               self.y_train[train_indices])
         else:
             test_pred = None
-
+        self.logger.debug("finished predicting on val/test set in tae")
         return train_pred, opt_pred, valid_pred, test_pred
 
 

--- a/autoPyTorch/pipeline/components/training/data_loader/base_data_loader.py
+++ b/autoPyTorch/pipeline/components/training/data_loader/base_data_loader.py
@@ -69,7 +69,8 @@ class BaseDataLoaderComponent(autoPyTorchTrainingComponent):
         Returns:
             (Dict[str, Any]): the updated fit dictionary
         """
-        X.update({'train_data_loader': self.train_data_loader,
+        X.update({'total_num_steps': len(X['train_indices'])//self.batch_size,
+                  'train_data_loader': self.train_data_loader,
                   'val_data_loader': self.val_data_loader,
                   'test_data_loader': self.test_data_loader})
         return X

--- a/autoPyTorch/pipeline/components/training/data_loader/base_data_loader.py
+++ b/autoPyTorch/pipeline/components/training/data_loader/base_data_loader.py
@@ -69,8 +69,7 @@ class BaseDataLoaderComponent(autoPyTorchTrainingComponent):
         Returns:
             (Dict[str, Any]): the updated fit dictionary
         """
-        X.update({'total_num_steps': len(X['train_indices'])//self.batch_size,
-                  'train_data_loader': self.train_data_loader,
+        X.update({'train_data_loader': self.train_data_loader,
                   'val_data_loader': self.val_data_loader,
                   'test_data_loader': self.test_data_loader})
         return X

--- a/autoPyTorch/pipeline/components/training/trainer/__init__.py
+++ b/autoPyTorch/pipeline/components/training/trainer/__init__.py
@@ -377,14 +377,14 @@ class TrainerChoice(autoPyTorchChoice):
             start_time = time.time()
 
             self.choice.on_epoch_start(X=X, epoch=epoch)
-            self.logger.debug(f" 1 epoch fit time: {self.choice.per_epoch_timelimit}, is_early_stopped : {self.choice.is_early_stopped} entered_train_epoch_loop: {self.choice.entered_train_epoch_loop}, total_num_steps: {X['total_num_steps']}")
+            self.logger.debug(f" Time limit to fit one epoch: {self.choice.per_epoch_timelimit}")
             # training
             train_loss, train_metrics = self.choice.train_epoch(
                 train_loader=X['train_data_loader'],
                 epoch=epoch,
                 writer=writer,
             )
-            self.logger.debug(f" epoch fit time: {self.choice.per_epoch_timelimit}, is_early_stopped : {self.choice.is_early_stopped} entered_train_epoch_loop: {self.choice.entered_train_epoch_loop}, last_step: {self.choice.last_step}")
+            self.logger.debug(f"Finished training for an epoch.")
             # its fine if train_loss is None due to `is_max_time_reached()`
             if train_loss is None:
                 if self.budget_tracker.is_max_time_reached():
@@ -400,7 +400,7 @@ class TrainerChoice(autoPyTorchChoice):
                 if 'test_data_loader' in X and X['test_data_loader']:
                     test_loss, test_metrics = self.choice.evaluate(X['test_data_loader'], epoch, writer)
 
-            self.logger.debug("Finished predicting inside base trsiner choice")
+            self.logger.debug("Finished predicting inside base trainer choice")
             # Save training information
             self.run_summary.add_performance(
                 epoch=epoch,

--- a/autoPyTorch/pipeline/components/training/trainer/base_trainer.py
+++ b/autoPyTorch/pipeline/components/training/trainer/base_trainer.py
@@ -327,10 +327,10 @@ class BaseTrainerComponent(autoPyTorchTrainingComponent):
 
         # task type (used for calculating metrics)
         self.task_type = task_type
-        self.entered_train_epoch_loop = False
-        self.is_early_stopped = None
+
+        # self.is_early_stopped = None
         self.start_time = start_time
-        self.last_step = 0
+
         # for cutout trainer, we need the list of numerical columns
         self.numerical_columns = numerical_columns
 
@@ -436,15 +436,14 @@ class BaseTrainerComponent(autoPyTorchTrainingComponent):
         targets_data = list()
 
         for step, (data, targets) in enumerate(train_loader):
-            self.entered_train_epoch_loop = True
-            if time.time() - self.start_time >= self.per_epoch_timelimit:
-                self.is_early_stopped = step
-                break
+            # if time.time() - self.start_time >= self.per_epoch_timelimit:
+            #     self.is_early_stopped = step
+            #     break
             if self.budget_tracker.is_max_time_reached():
                 break
 
             loss, outputs = self.train_step(data, targets)
-            self.last_step += 1
+
             # save for metric evaluation
             outputs_data.append(outputs.detach().cpu())
             targets_data.append(targets.detach().cpu())

--- a/test/test_data/test_utils.py
+++ b/test/test_data/test_utils.py
@@ -25,7 +25,7 @@ from autoPyTorch.constants import (
 from autoPyTorch.data.utils import (
     default_dataset_compression_arg,
     get_dataset_compression_mapping,
-    megabytes,
+    get_approximate_mem_usage_in_mb,
     reduce_dataset_size_if_too_large,
     reduce_precision,
     subsample,
@@ -51,7 +51,7 @@ def test_reduce_dataset_if_too_large(openmlid, as_frame, n_samples):
     assert X_converted.shape[0] < X.shape[0]
     assert y_converted.shape[0] < y.shape[0]
 
-    assert megabytes(X_converted) < megabytes(X)
+    assert get_approximate_mem_usage_in_mb(X_converted) < get_approximate_mem_usage_in_mb(X)
 
 
 @pytest.mark.parametrize("X", [np.asarray([[1, 1, 1]] * 30)])

--- a/test/test_data/test_validation.py
+++ b/test/test_data/test_validation.py
@@ -8,7 +8,7 @@ import sklearn.datasets
 import sklearn.model_selection
 
 from autoPyTorch.data.tabular_validator import TabularInputValidator
-from autoPyTorch.data.utils import megabytes
+from autoPyTorch.data.utils import get_approximate_mem_usage_in_mb
 
 
 @pytest.mark.parametrize('openmlid', [2, 40975, 40984])
@@ -148,16 +148,16 @@ def test_featurevalidator_dataset_compression(input_data_featuretest):
     X_train, X_test, y_train, y_test = sklearn.model_selection.train_test_split(
         input_data_featuretest, input_data_targets, test_size=0.1, random_state=1)
     validator = TabularInputValidator(
-        dataset_compression={'memory_allocation': 0.8 * megabytes(X_train), 'methods': ['precision', 'subsample']}
+        dataset_compression={'memory_allocation': 0.8 * get_approximate_mem_usage_in_mb(X_train), 'methods': ['precision', 'subsample']}
     )
     validator.fit(X_train=X_train, y_train=y_train)
     transformed_X_train, _ = validator.transform(X_train.copy(), y_train.copy())
 
     assert validator._reduced_dtype is not None
-    assert megabytes(transformed_X_train) < megabytes(X_train)
+    assert get_approximate_mem_usage_in_mb(transformed_X_train) < get_approximate_mem_usage_in_mb(X_train)
 
     transformed_X_test, _ = validator.transform(X_test.copy(), y_test.copy())
-    assert megabytes(transformed_X_test) < megabytes(X_test)
+    assert get_approximate_mem_usage_in_mb(transformed_X_test) < get_approximate_mem_usage_in_mb(X_test)
     if hasattr(transformed_X_train, 'iloc'):
         assert all(transformed_X_train.dtypes == transformed_X_test.dtypes)
         assert all(transformed_X_train.dtypes == validator._precision)


### PR DESCRIPTION
This PR aims to improve the approximate memory usage of a dataset by considering the dataset after transforming with one hot encoding. Based on our experiments (reg cocktails ablation study), we have observed that columns with high cardinality of their categorical features tend to explode when they are one hot encoded. Moreover, even with the addition of pytorch embedding (removing the need to one hot encode all categorical columns), we observe that excessive memory is used while building the neural network. 

This PR also includes some debug statements to help understand the time used for various functions while training for an epoch as well as commented code to enable early stopping of the training of a model based on how many batches it can finish for a given epoch time. 