### PR TITLE
[ADD] Allow users to pass feat types to tabular validator

### DIFF
--- a/autoPyTorch/api/base_task.py
+++ b/autoPyTorch/api/base_task.py
@@ -307,6 +307,7 @@ class BaseTask(ABC):
         resampling_strategy_args: Optional[Dict[str, Any]] = None,
         dataset_name: Optional[str] = None,
         dataset_compression: Optional[DatasetCompressionSpec] = None,
+        **kwargs: Any
     ) -> Tuple[BaseDataset, BaseInputValidator]:
         """
         Returns an object of a child class of `BaseDataset` and
@@ -353,6 +354,7 @@ class BaseTask(ABC):
         resampling_strategy_args: Optional[Dict[str, Any]] = None,
         dataset_name: Optional[str] = None,
         dataset_compression: Optional[DatasetCompressionSpec] = None,
+        **kwargs: Any
     ) -> BaseDataset:
         """
         Returns an object of a child class of `BaseDataset` according to the current task.
@@ -407,6 +409,10 @@ class BaseTask(ABC):
                         Subsampling takes into account classification labels and stratifies
                         accordingly. We guarantee that at least one occurrence of each
                         label is included in the sampled set.
+            kwargs (Any):
+                can be used to pass task specific dataset arguments. Currently supports
+                passing `feat_types` for tabular tasks which specifies whether a feature is
+                'numerical' or 'categorical'.
 
         Returns:
             BaseDataset:
@@ -420,7 +426,8 @@ class BaseTask(ABC):
             resampling_strategy=resampling_strategy,
             resampling_strategy_args=resampling_strategy_args,
             dataset_name=dataset_name,
-            dataset_compression=dataset_compression)
+            dataset_compression=dataset_compression,
+            **kwargs)
 
         return dataset
 

--- a/autoPyTorch/api/tabular_classification.py
+++ b/autoPyTorch/api/tabular_classification.py
@@ -96,6 +96,7 @@ class TabularClassificationTask(BaseTask):
         exclude_components: Optional[Dict[str, Any]] = None,
         resampling_strategy: ResamplingStrategies = HoldoutValTypes.holdout_validation,
         resampling_strategy_args: Optional[Dict[str, Any]] = None,
+        feat_types: Optional[List[str]] = None,
         backend: Optional[Backend] = None,
         search_space_updates: Optional[HyperparameterSearchSpaceUpdates] = None
     ):
@@ -119,6 +120,7 @@ class TabularClassificationTask(BaseTask):
             search_space_updates=search_space_updates,
             task_type=TASK_TYPES_TO_STRING[TABULAR_CLASSIFICATION],
         )
+        self.feat_types = feat_types
 
     def build_pipeline(
         self,
@@ -168,6 +170,7 @@ class TabularClassificationTask(BaseTask):
         resampling_strategy_args: Optional[Dict[str, Any]] = None,
         dataset_name: Optional[str] = None,
         dataset_compression: Optional[DatasetCompressionSpec] = None,
+        **kwargs: Any,
     ) -> Tuple[TabularDataset, TabularInputValidator]:
         """
         Returns an object of `TabularDataset` and an object of
@@ -194,6 +197,9 @@ class TabularClassificationTask(BaseTask):
             dataset_compression (Optional[DatasetCompressionSpec]):
                 specifications for dataset compression. For more info check
                 documentation for `BaseTask.get_dataset`.
+            kwargs (Any):
+                Currently for tabular tasks, expect `feat_types: (Optional[List[str]]` which
+                specifies whether a feature is 'numerical' or 'categorical'.
 
         Returns:
             TabularDataset:
@@ -206,12 +212,14 @@ class TabularClassificationTask(BaseTask):
         resampling_strategy_args = resampling_strategy_args if resampling_strategy_args is not None else \
             self.resampling_strategy_args
 
+        feat_types = kwargs.pop('feat_types', self.feat_types)
         # Create a validator object to make sure that the data provided by
         # the user matches the autopytorch requirements
         input_validator = TabularInputValidator(
             is_classification=True,
             logger_port=self._logger_port,
-            dataset_compression=dataset_compression
+            dataset_compression=dataset_compression,
+            feat_types=feat_types
         )
 
         # Fit a input validator to check the provided data

--- a/autoPyTorch/api/tabular_classification.py
+++ b/autoPyTorch/api/tabular_classification.py
@@ -96,7 +96,6 @@ class TabularClassificationTask(BaseTask):
         exclude_components: Optional[Dict[str, Any]] = None,
         resampling_strategy: ResamplingStrategies = HoldoutValTypes.holdout_validation,
         resampling_strategy_args: Optional[Dict[str, Any]] = None,
-        feat_types: Optional[List[str]] = None,
         backend: Optional[Backend] = None,
         search_space_updates: Optional[HyperparameterSearchSpaceUpdates] = None
     ):
@@ -120,7 +119,6 @@ class TabularClassificationTask(BaseTask):
             search_space_updates=search_space_updates,
             task_type=TASK_TYPES_TO_STRING[TABULAR_CLASSIFICATION],
         )
-        self.feat_types = feat_types
 
     def build_pipeline(
         self,
@@ -212,7 +210,7 @@ class TabularClassificationTask(BaseTask):
         resampling_strategy_args = resampling_strategy_args if resampling_strategy_args is not None else \
             self.resampling_strategy_args
 
-        feat_types = kwargs.pop('feat_types', self.feat_types)
+        feat_types = kwargs.pop('feat_types', None)
         # Create a validator object to make sure that the data provided by
         # the user matches the autopytorch requirements
         input_validator = TabularInputValidator(
@@ -246,6 +244,7 @@ class TabularClassificationTask(BaseTask):
         X_test: Optional[Union[List, pd.DataFrame, np.ndarray]] = None,
         y_test: Optional[Union[List, pd.DataFrame, np.ndarray]] = None,
         dataset_name: Optional[str] = None,
+        feat_types: Optional[List[str]] = None,
         budget_type: str = 'epochs',
         min_budget: int = 5,
         max_budget: int = 50,
@@ -274,6 +273,10 @@ class TabularClassificationTask(BaseTask):
                 A pair of features (X_train) and targets (y_train) used to fit a
                 pipeline. Additionally, a holdout of this pairs (X_test, y_test) can
                 be provided to track the generalization performance of each stage.
+            feat_types (Optional[List[str]]):
+                Description about the feature types of the columns.
+                Accepts `numerical` for integers, float data and `categorical`
+                for categories, strings and bool. Defaults to None.
             optimize_metric (str):
                 name of the metric that is used to evaluate a pipeline.
             budget_type (str):
@@ -441,7 +444,8 @@ class TabularClassificationTask(BaseTask):
             resampling_strategy=self.resampling_strategy,
             resampling_strategy_args=self.resampling_strategy_args,
             dataset_name=dataset_name,
-            dataset_compression=self._dataset_compression)
+            dataset_compression=self._dataset_compression,
+            feat_types=feat_types)
 
         return self._search(
             dataset=self.dataset,

--- a/autoPyTorch/api/tabular_regression.py
+++ b/autoPyTorch/api/tabular_regression.py
@@ -97,6 +97,7 @@ class TabularRegressionTask(BaseTask):
         exclude_components: Optional[Dict[str, Any]] = None,
         resampling_strategy: ResamplingStrategies = HoldoutValTypes.holdout_validation,
         resampling_strategy_args: Optional[Dict[str, Any]] = None,
+        feat_types: Optional[List[str]] = None,
         backend: Optional[Backend] = None,
         search_space_updates: Optional[HyperparameterSearchSpaceUpdates] = None
     ):
@@ -120,6 +121,7 @@ class TabularRegressionTask(BaseTask):
             search_space_updates=search_space_updates,
             task_type=TASK_TYPES_TO_STRING[TABULAR_REGRESSION],
         )
+        self.feat_types = feat_types
 
     def build_pipeline(
         self,
@@ -169,6 +171,7 @@ class TabularRegressionTask(BaseTask):
         resampling_strategy_args: Optional[Dict[str, Any]] = None,
         dataset_name: Optional[str] = None,
         dataset_compression: Optional[DatasetCompressionSpec] = None,
+        **kwargs: Any
     ) -> Tuple[TabularDataset, TabularInputValidator]:
         """
         Returns an object of `TabularDataset` and an object of
@@ -195,6 +198,9 @@ class TabularRegressionTask(BaseTask):
             dataset_compression (Optional[DatasetCompressionSpec]):
                 specifications for dataset compression. For more info check
                 documentation for `BaseTask.get_dataset`.
+            kwargs (Any):
+                Currently for tabular tasks, expect `feat_types: (Optional[List[str]]` which
+                specifies whether a feature is 'numerical' or 'categorical'.
         Returns:
             TabularDataset:
                 the dataset object.
@@ -206,12 +212,14 @@ class TabularRegressionTask(BaseTask):
         resampling_strategy_args = resampling_strategy_args if resampling_strategy_args is not None else \
             self.resampling_strategy_args
 
+        feat_types = kwargs.pop('feat_types', self.feat_types)
         # Create a validator object to make sure that the data provided by
         # the user matches the autopytorch requirements
         input_validator = TabularInputValidator(
             is_classification=False,
             logger_port=self._logger_port,
-            dataset_compression=dataset_compression
+            dataset_compression=dataset_compression,
+            feat_types=feat_types
         )
 
         # Fit a input validator to check the provided data

--- a/autoPyTorch/api/tabular_regression.py
+++ b/autoPyTorch/api/tabular_regression.py
@@ -97,7 +97,6 @@ class TabularRegressionTask(BaseTask):
         exclude_components: Optional[Dict[str, Any]] = None,
         resampling_strategy: ResamplingStrategies = HoldoutValTypes.holdout_validation,
         resampling_strategy_args: Optional[Dict[str, Any]] = None,
-        feat_types: Optional[List[str]] = None,
         backend: Optional[Backend] = None,
         search_space_updates: Optional[HyperparameterSearchSpaceUpdates] = None
     ):
@@ -121,7 +120,6 @@ class TabularRegressionTask(BaseTask):
             search_space_updates=search_space_updates,
             task_type=TASK_TYPES_TO_STRING[TABULAR_REGRESSION],
         )
-        self.feat_types = feat_types
 
     def build_pipeline(
         self,
@@ -212,7 +210,7 @@ class TabularRegressionTask(BaseTask):
         resampling_strategy_args = resampling_strategy_args if resampling_strategy_args is not None else \
             self.resampling_strategy_args
 
-        feat_types = kwargs.pop('feat_types', self.feat_types)
+        feat_types = kwargs.pop('feat_types', None)
         # Create a validator object to make sure that the data provided by
         # the user matches the autopytorch requirements
         input_validator = TabularInputValidator(
@@ -246,6 +244,7 @@ class TabularRegressionTask(BaseTask):
         X_test: Optional[Union[List, pd.DataFrame, np.ndarray]] = None,
         y_test: Optional[Union[List, pd.DataFrame, np.ndarray]] = None,
         dataset_name: Optional[str] = None,
+        feat_types: Optional[List[str]] = None,
         budget_type: str = 'epochs',
         min_budget: int = 5,
         max_budget: int = 50,
@@ -274,6 +273,10 @@ class TabularRegressionTask(BaseTask):
                 A pair of features (X_train) and targets (y_train) used to fit a
                 pipeline. Additionally, a holdout of this pairs (X_test, y_test) can
                 be provided to track the generalization performance of each stage.
+            feat_types (Optional[List[str]]):
+                Description about the feature types of the columns.
+                Accepts `numerical` for integers, float data and `categorical`
+                for categories, strings and bool. Defaults to None.
             optimize_metric (str):
                 Name of the metric that is used to evaluate a pipeline.
             budget_type (str):
@@ -442,7 +445,8 @@ class TabularRegressionTask(BaseTask):
             resampling_strategy=self.resampling_strategy,
             resampling_strategy_args=self.resampling_strategy_args,
             dataset_name=dataset_name,
-            dataset_compression=self._dataset_compression)
+            dataset_compression=self._dataset_compression,
+            feat_types=feat_types)
 
         return self._search(
             dataset=self.dataset,

--- a/autoPyTorch/data/base_feature_validator.py
+++ b/autoPyTorch/data/base_feature_validator.py
@@ -35,7 +35,7 @@ class BaseFeatureValidator(BaseEstimator):
         logger: Optional[Union[PicklableClientLogger, logging.Logger]] = None,
     ):
         # Register types to detect unsupported data format changes
-        self.feat_type: Optional[List[str]] = None
+        self.feat_types: Optional[List[str]] = None
         self.data_type: Optional[type] = None
         self.dtypes: List[str] = []
         self.column_order: List[str] = []

--- a/autoPyTorch/data/tabular_feature_validator.py
+++ b/autoPyTorch/data/tabular_feature_validator.py
@@ -365,8 +365,8 @@ class TabularFeatureValidator(BaseFeatureValidator):
 
     def get_columns_to_encode(
         self,
-        X: SupportedFeatTypes
-        ) -> Tuple[List[str], List[str]]:
+        X: pd.DataFrame
+    ) -> Tuple[List[str], List[str]]:
         """
         Return the columns to be transformed as well as
         the type of feature for each column.
@@ -389,10 +389,11 @@ class TabularFeatureValidator(BaseFeatureValidator):
             if len(self.feat_types) != len(X.columns):
                 raise ValueError(f"Expected number of `feat_types`: {len(self.feat_types)}"
                                  f" to be the same as the number of features {len(X.columns)}")
-            transformed_columns = [X.columns[i] for i, col in enumerate(self.feat_types) if col.lower() == 'categorical']
+            transformed_columns = [X.columns[i] for i, col in enumerate(self.feat_types)
+                                   if col.lower() == 'categorical']
             return transformed_columns, self.feat_types
         else:
-            transformed_columns, feat_types
+            return transformed_columns, feat_types
 
     def _get_columns_to_encode(
         self,

--- a/autoPyTorch/data/tabular_feature_validator.py
+++ b/autoPyTorch/data/tabular_feature_validator.py
@@ -390,14 +390,36 @@ class TabularFeatureValidator(BaseFeatureValidator):
         """
         transformed_columns, feat_types = self._get_columns_to_encode(X)
         if self.feat_types is not None:
-            if len(self.feat_types) != len(X.columns):
-                raise ValueError(f"Expected number of `feat_types`: {len(self.feat_types)}"
-                                 f" to be the same as the number of features {len(X.columns)}")
+            self._validate_feat_types(X)
             transformed_columns = [X.columns[i] for i, col in enumerate(self.feat_types)
                                    if col.lower() == 'categorical']
             return transformed_columns, self.feat_types
         else:
             return transformed_columns, feat_types
+
+    def _validate_feat_types(self, X: pd.DataFrame):
+        """
+        Checks if the passed `feat_types` is compatible with what 
+        AutoPyTorch expects, i.e, it should only contain `numerical` 
+        or `categorical`. The case does not matter. 
+
+        Args:
+            X (pd.DataFrame):
+                input features set
+
+        Raises:
+            ValueError:
+                if the number of feat_types is not equal to the number of features
+                if the feature type are not one of "numerical", "categorical"
+
+        """
+        if len(self.feat_types) != len(X.columns):
+            raise ValueError(f"Expected number of `feat_types`: {len(self.feat_types)}"
+                             f" to be the same as the number of features {len(X.columns)}")
+        for feat_type in set(self.feat_types):
+            if feat_type.lower() not in ['numerical', 'categorical']:
+                raise ValueError(f"Expected type of features to be in `['numerical', "
+                                 f"'categorical']`, but got {feat_type}")
 
     def _get_columns_to_encode(
         self,

--- a/autoPyTorch/data/tabular_feature_validator.py
+++ b/autoPyTorch/data/tabular_feature_validator.py
@@ -94,6 +94,10 @@ class TabularFeatureValidator(BaseFeatureValidator):
             List of indices of numerical columns
         categorical_columns (List[int]):
             List of indices of categorical columns
+        feat_types (List[str]):
+                Description about the feature types of the columns.
+                Accepts `numerical` for integers, float data and `categorical`
+                for categories, strings and bool.
     """
     def __init__(
         self,

--- a/autoPyTorch/data/tabular_feature_validator.py
+++ b/autoPyTorch/data/tabular_feature_validator.py
@@ -397,11 +397,12 @@ class TabularFeatureValidator(BaseFeatureValidator):
         else:
             return transformed_columns, feat_types
 
-    def _validate_feat_types(self, X: pd.DataFrame):
+    def _validate_feat_types(self, X: pd.DataFrame) -> None:
         """
-        Checks if the passed `feat_types` is compatible with what 
-        AutoPyTorch expects, i.e, it should only contain `numerical` 
-        or `categorical`. The case does not matter. 
+        Checks if the passed `feat_types` is compatible with what
+        AutoPyTorch expects, i.e, it should only contain `numerical`
+        or `categorical` and the number of feature types is equal to
+        the number of features. The case does not matter.
 
         Args:
             X (pd.DataFrame):
@@ -411,8 +412,9 @@ class TabularFeatureValidator(BaseFeatureValidator):
             ValueError:
                 if the number of feat_types is not equal to the number of features
                 if the feature type are not one of "numerical", "categorical"
-
         """
+        assert self.feat_types is not None  # mypy check
+
         if len(self.feat_types) != len(X.columns):
             raise ValueError(f"Expected number of `feat_types`: {len(self.feat_types)}"
                              f" to be the same as the number of features {len(X.columns)}")

--- a/autoPyTorch/data/tabular_feature_validator.py
+++ b/autoPyTorch/data/tabular_feature_validator.py
@@ -98,8 +98,10 @@ class TabularFeatureValidator(BaseFeatureValidator):
     def __init__(
         self,
         logger: Optional[Union[PicklableClientLogger, Logger]] = None,
+        feat_types: Optional[List[str]] = None,
     ):
         super().__init__(logger)
+        self.feat_types = feat_types
 
     @staticmethod
     def _comparator(cmp1: str, cmp2: str) -> int:
@@ -167,9 +169,9 @@ class TabularFeatureValidator(BaseFeatureValidator):
             if not X.select_dtypes(include='object').empty:
                 X = self.infer_objects(X)
 
-            self.transformed_columns, self.feat_type = self._get_columns_to_encode(X)
+            self.transformed_columns, self.feat_types = self.get_columns_to_encode(X)
 
-            assert self.feat_type is not None
+            assert self.feat_types is not None
 
             if len(self.transformed_columns) > 0:
 
@@ -186,8 +188,8 @@ class TabularFeatureValidator(BaseFeatureValidator):
                 # The column transformer reorders the feature types
                 # therefore, we need to change the order of columns as well
                 # This means categorical columns are shifted to the left
-                self.feat_type = sorted(
-                    self.feat_type,
+                self.feat_types = sorted(
+                    self.feat_types,
                     key=functools.cmp_to_key(self._comparator)
                 )
 
@@ -201,7 +203,7 @@ class TabularFeatureValidator(BaseFeatureValidator):
                     for cat in encoded_categories
                 ]
 
-            for i, type_ in enumerate(self.feat_type):
+            for i, type_ in enumerate(self.feat_types):
                 if 'numerical' in type_:
                     self.numerical_columns.append(i)
                 else:
@@ -336,7 +338,7 @@ class TabularFeatureValidator(BaseFeatureValidator):
 
             # Define the column to be encoded here as the feature validator is fitted once
             # per estimator
-            self.transformed_columns, self.feat_type = self._get_columns_to_encode(X)
+            self.transformed_columns, self.feat_types = self.get_columns_to_encode(X)
 
             column_order = [column for column in X.columns]
             if len(self.column_order) > 0:
@@ -361,12 +363,47 @@ class TabularFeatureValidator(BaseFeatureValidator):
             else:
                 self.dtypes = dtypes
 
+    def get_columns_to_encode(
+        self,
+        X: SupportedFeatTypes
+        ) -> Tuple[List[str], List[str]]:
+        """
+        Return the columns to be transformed as well as
+        the type of feature for each column.
+
+        The returned values are dependent on `feat_types` passed to the `__init__`.
+
+        Args:
+            X (pd.DataFrame)
+                A set of features that are going to be validated (type and dimensionality
+                checks) and an encoder fitted in the case the data needs encoding
+
+        Returns:
+            transformed_columns (List[str]):
+                Columns to encode, if any
+            feat_type:
+                Type of each column numerical/categorical
+        """
+        transformed_columns, feat_types = self._get_columns_to_encode(X)
+        if self.feat_types is not None:
+            if len(self.feat_types) != len(X.columns):
+                raise ValueError(f"Expected number of `feat_types`: {len(self.feat_types)}"
+                                 f" to be the same as the number of features {len(X.columns)}")
+            transformed_columns = [X.columns[i] for i, col in enumerate(self.feat_types) if col.lower() == 'categorical']
+            return transformed_columns, self.feat_types
+        else:
+            transformed_columns, feat_types
+
     def _get_columns_to_encode(
         self,
         X: pd.DataFrame,
     ) -> Tuple[List[str], List[str]]:
         """
-        Return the columns to be encoded from a pandas dataframe
+        Return the columns to be transformed as well as
+        the type of feature for each column from a pandas dataframe.
+
+        If `self.feat_types` is not None, it also validates that the
+        dataframe dtypes dont disagree with the ones passed in `__init__`.
 
         Args:
             X (pd.DataFrame)
@@ -380,21 +417,24 @@ class TabularFeatureValidator(BaseFeatureValidator):
                 Type of each column numerical/categorical
         """
 
-        if len(self.transformed_columns) > 0 and self.feat_type is not None:
-            return self.transformed_columns, self.feat_type
+        if len(self.transformed_columns) > 0 and self.feat_types is not None:
+            return self.transformed_columns, self.feat_types
 
         # Register if a column needs encoding
         transformed_columns = []
 
         # Also, register the feature types for the estimator
-        feat_type = []
+        feat_types = []
 
         # Make sure each column is a valid type
         for i, column in enumerate(X.columns):
             if X[column].dtype.name in ['category', 'bool']:
 
                 transformed_columns.append(column)
-                feat_type.append('categorical')
+                if self.feat_types is not None and self.feat_types[i].lower() == 'numerical':
+                    raise ValueError(f"Passed numerical as the feature type for column: {column} "
+                                     f"but the column is categorical")
+                feat_types.append('categorical')
             # Move away from np.issubdtype as it causes
             # TypeError: data type not understood in certain pandas types
             elif not is_numeric_dtype(X[column]):
@@ -434,8 +474,8 @@ class TabularFeatureValidator(BaseFeatureValidator):
                         )
                     )
             else:
-                feat_type.append('numerical')
-        return transformed_columns, feat_type
+                feat_types.append('numerical')
+        return transformed_columns, feat_types
 
     def list_to_dataframe(
         self,

--- a/autoPyTorch/data/tabular_validator.py
+++ b/autoPyTorch/data/tabular_validator.py
@@ -41,6 +41,10 @@ class TabularInputValidator(BaseInputValidator):
         dataset_compression (Optional[DatasetCompressionSpec]):
             specifications for dataset compression. For more info check
             documentation for `BaseTask.get_dataset`.
+        feat_types (List[str]):
+                Description about the feature types of the columns.
+                Accepts `numerical` for integers, float data and `categorical`
+                for categories, strings and bool
     """
     def __init__(
         self,

--- a/autoPyTorch/data/tabular_validator.py
+++ b/autoPyTorch/data/tabular_validator.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 import logging
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -47,6 +47,7 @@ class TabularInputValidator(BaseInputValidator):
         is_classification: bool = False,
         logger_port: Optional[int] = None,
         dataset_compression: Optional[DatasetCompressionSpec] = None,
+        feat_types: Optional[List[str]] = None,
         seed: int = 42,
     ):
         self.dataset_compression = dataset_compression
@@ -63,7 +64,8 @@ class TabularInputValidator(BaseInputValidator):
             self.logger = logging.getLogger('Validation')
 
         self.feature_validator = TabularFeatureValidator(
-            logger=self.logger)
+            logger=self.logger,
+            feat_types=feat_types)
         self.target_validator = TabularTargetValidator(
             is_classification=self.is_classification,
             logger=self.logger

--- a/autoPyTorch/data/tabular_validator.py
+++ b/autoPyTorch/data/tabular_validator.py
@@ -58,6 +58,7 @@ class TabularInputValidator(BaseInputValidator):
         self._reduced_dtype: Optional[DatasetDTypeContainerType] = None
         self.is_classification = is_classification
         self.logger_port = logger_port
+        self.feat_types = feat_types
         self.seed = seed
         if self.logger_port is not None:
             self.logger: Union[logging.Logger, PicklableClientLogger] = get_named_client_logger(
@@ -69,7 +70,7 @@ class TabularInputValidator(BaseInputValidator):
 
         self.feature_validator = TabularFeatureValidator(
             logger=self.logger,
-            feat_types=feat_types)
+            feat_types=self.feat_types)
         self.target_validator = TabularTargetValidator(
             is_classification=self.is_classification,
             logger=self.logger

--- a/examples/40_advanced/example_pass_feature_types.py
+++ b/examples/40_advanced/example_pass_feature_types.py
@@ -1,0 +1,93 @@
+"""
+=====================================================
+Tabular Classification with user passed feature types
+=====================================================
+
+The following example shows how to pass feature typesfor datasets which are in 
+numpy format (also works for dataframes and lists) fit a sample classification 
+model with AutoPyTorch.
+
+AutoPyTorch relies on column dtypes for intepreting the feature types. But they 
+can be misinterpreted for example, when dataset is passed as a numpy array, all 
+the data is interpreted as numerical if it's dtype is int or float. However, the 
+categorical values could have been encoded as integers.
+
+Passing feature types helps AutoPyTorch interpreting them correctly as well as
+validates the dataset by checking the dtype of the columns for any incompatibilities.
+"""
+import os
+import tempfile as tmp
+import warnings
+
+os.environ['JOBLIB_TEMP_FOLDER'] = tmp.gettempdir()
+os.environ['OMP_NUM_THREADS'] = '1'
+os.environ['OPENBLAS_NUM_THREADS'] = '1'
+os.environ['MKL_NUM_THREADS'] = '1'
+
+warnings.simplefilter(action='ignore', category=UserWarning)
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
+import openml
+import sklearn.model_selection
+
+from autoPyTorch.api.tabular_classification import TabularClassificationTask
+
+
+############################################################################
+# Data Loading
+# ============
+task = openml.tasks.get_task(task_id=146821)
+dataset = task.get_dataset()
+X, y, categorical_indicator, _ = dataset.get_data(
+    dataset_format='array',
+    target=dataset.default_target_attribute,
+)
+X_train, X_test, y_train, y_test = sklearn.model_selection.train_test_split(
+    X,
+    y,
+    random_state=1,
+)
+
+feat_types = ["numerical" if not indicator else "categorical" for indicator in categorical_indicator]
+
+# 
+############################################################################
+# Build and fit a classifier
+# ==========================
+api = TabularClassificationTask(
+    # To maintain logs of the run, you can uncomment the
+    # Following lines
+    # temporary_directory='./tmp/autoPyTorch_example_tmp_01',
+    # output_directory='./tmp/autoPyTorch_example_out_01',
+    # delete_tmp_folder_after_terminate=False,
+    # delete_output_folder_after_terminate=False,
+    seed=42,
+)
+
+############################################################################
+# Search for an ensemble of machine learning algorithms
+# =====================================================
+api.search(
+    X_train=X_train,
+    y_train=y_train,
+    X_test=X_test.copy(),
+    y_test=y_test.copy(),
+    dataset_name='Australian',
+    optimize_metric='accuracy',
+    total_walltime_limit=100,
+    func_eval_time_limit_secs=50,
+    feat_types=feat_types,
+    enable_traditional_pipeline=False
+)
+
+############################################################################
+# Print the final ensemble performance
+# ====================================
+y_pred = api.predict(X_test)
+score = api.score(y_pred, y_test)
+print(score)
+# Print the final ensemble built by AutoPyTorch
+print(api.show_models())
+
+# Print statistics from search
+print(api.sprint_statistics())

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setuptools.setup(
             "jupyter",
             "notebook",
             "seaborn",
+            "openml"
         ],
         "docs": ["sphinx", "sphinx-gallery", "sphinx_bootstrap_theme", "numpydoc"],
     },

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -59,6 +59,10 @@ def callattr_ahead_of_alltests(request):
         4871,    # sensory
         4857,    # boston
         3916,    # kc1
+        2295,    # cholesterol
+        3916,    # kc1-binary
+        293554,  # reuters
+        294846   # rf1
     ]
 
     # Populate the cache

--- a/test/test_data/test_feature_validator.py
+++ b/test/test_data/test_feature_validator.py
@@ -439,6 +439,12 @@ def input_data_feature_feat_types(request):
             {'A': 3, 'B': '4'},
         ], dtype='category')
         return frame, ['categorical', 'categorical', 'numerical']
+    elif request.param == 'pandas_feat_type_error':
+        frame = pd.DataFrame([
+            {'A': 1, 'B': '2'},
+            {'A': 3, 'B': '4'},
+        ], dtype='category')
+        return frame, ['not_categorical', 'numerical']
     else:
         ValueError("Unsupported indirect fixture {}".format(request.param))
 
@@ -500,4 +506,23 @@ def test_feature_validator_get_columns_to_encode_error_length(input_data_feature
     X, feat_types = input_data_feature_feat_types
     validator = TabularFeatureValidator(feat_types=feat_types)
     with pytest.raises(ValueError, match=r"Expected number of `feat_types`: .*"):
-        validator.get_columns_to_encode(X)
+        validator._validate_feat_types(X)
+
+
+@pytest.mark.parametrize(
+    'input_data_feature_feat_types',
+    (
+        'pandas_feat_type_error',
+    ),
+    indirect=True
+)
+def test_feature_validator_get_columns_to_encode_error_feat_type(input_data_feature_feat_types):
+    """
+    Tests the correct error is raised when the length of feat types passed to
+    the validator is not the same as the number of features
+
+    """
+    X, feat_types = input_data_feature_feat_types
+    validator = TabularFeatureValidator(feat_types=feat_types)
+    with pytest.raises(ValueError, match=r"Expected type of features to be in .*"):
+        validator._validate_feat_types(X)

--- a/test/test_data/test_feature_validator.py
+++ b/test/test_data/test_feature_validator.py
@@ -479,7 +479,8 @@ def test_feature_validator_get_columns_to_encode_error_string(input_data_feature
     """
     X, feat_types = input_data_feature_feat_types
     validator = TabularFeatureValidator(feat_types=feat_types)
-    with pytest.raises(ValueError, match=r"Passed numerical as the feature type for column: B but the column is categorical"):
+    with pytest.raises(ValueError, match=r"Passed numerical as the feature type for column: B but "
+                                         r"the column is categorical"):
         validator.get_columns_to_encode(X)
 
 

--- a/test/test_data/test_target_validator.py
+++ b/test/test_data/test_target_validator.py
@@ -126,7 +126,7 @@ def input_data_targettest(request):
         'sparse_csc_nonan',
         'sparse_csr_nonan',
         'sparse_lil_nonan',
-        'openml_204',
+        'openml_204',  # openml cholesterol dataset
     ),
     indirect=True
 )
@@ -182,7 +182,7 @@ def test_targetvalidator_supported_types_noclassification(input_data_targettest)
         'sparse_csc_nonan',
         'sparse_csr_nonan',
         'sparse_lil_nonan',
-        'openml_2',
+        'openml_2',  # anneal dataset
     ),
     indirect=True
 )
@@ -246,7 +246,7 @@ def test_targetvalidator_supported_types_classification(input_data_targettest):
         'pandas_binary',
         'numpy_binary',
         'list_binary',
-        'openml_1066',
+        'openml_1066',  # kc1-binary dataset
     ),
     indirect=True
 )
@@ -266,7 +266,7 @@ def test_targetvalidator_binary(input_data_targettest):
         'pandas_multiclass',
         'numpy_multiclass',
         'list_multiclass',
-        'openml_54',
+        'openml_54',  # vehicle dataset
     ),
     indirect=True
 )
@@ -285,7 +285,7 @@ def test_targetvalidator_multiclass(input_data_targettest):
         'pandas_multilabel',
         'numpy_multilabel',
         'list_multilabel',
-        'openml_40594',
+        'openml_40594',  # reuters dataset
     ),
     indirect=True
 )
@@ -305,7 +305,7 @@ def test_targetvalidator_multilabel(input_data_targettest):
         'pandas_continuous',
         'numpy_continuous',
         'list_continuous',
-        'openml_531',
+        'openml_531',  # boston dataset
     ),
     indirect=True
 )
@@ -324,7 +324,7 @@ def test_targetvalidator_continuous(input_data_targettest):
         'pandas_continuous-multioutput',
         'numpy_continuous-multioutput',
         'list_continuous-multioutput',
-        'openml_41483',
+        'openml_41483',  # rf1 dataset
     ),
     indirect=True
 )

--- a/test/test_data/test_validation.py
+++ b/test/test_data/test_validation.py
@@ -49,8 +49,8 @@ def test_data_validation_for_classification(openmlid, as_frame):
 
     # Categorical columns are sorted to the beginning
     if as_frame:
-        validator.feature_validator.feat_type is not None
-        ordered_unique_elements = list(dict.fromkeys(validator.feature_validator.feat_type))
+        validator.feature_validator.feat_types is not None
+        ordered_unique_elements = list(dict.fromkeys(validator.feature_validator.feat_types))
         if len(ordered_unique_elements) > 1:
             assert ordered_unique_elements[0] == 'categorical'
 
@@ -91,8 +91,8 @@ def test_data_validation_for_regression(openmlid, as_frame):
 
     # Categorical columns are sorted to the beginning
     if as_frame:
-        validator.feature_validator.feat_type is not None
-        ordered_unique_elements = list(dict.fromkeys(validator.feature_validator.feat_type))
+        validator.feature_validator.feat_types is not None
+        ordered_unique_elements = list(dict.fromkeys(validator.feature_validator.feat_types))
         if len(ordered_unique_elements) > 1:
             assert ordered_unique_elements[0] == 'categorical'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR introduces changes to allow users to pass feature types to the tabular validator. When passing NumPy arrays, autoPyTorch can now accept a list describing the feature types of each column whereas previously all columns would have been interpreted as numerical. 

This PR resolves #394.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

Note that a Pull Request should only contain one of refactoring, new features or documentation changes.
Please separate these changes and send us individual PRs for each.
For more information on how to create a good pull request, please refer to [The anatomy of a perfect pull request](https://medium.com/@hugooodias/the-anatomy-of-a-perfect-pull-request-567382bb6067).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
<!-- 
* [ ] Have you followed the guidelines in our Contributing document?
-->


## Description
<!--- Describe your changes in detail -->
I have allowed `feat_types` to be passed via the `api.search` for `TabularClassificationTask` and `TabularRegressionTask`. These are passed to the `TabularFeatureValidator` where they are used to validate whether these passed feature types match the column dtypes as well as to determine the columns that need to be transformed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
AutoPyTorch relies on column dtypes for interpreting the feature types. But they 
can be misinterpreted, for example, when the dataset is passed as a NumPy array, all 
the data is interpreted as numerical if its dtype is int or float. However, the 
categorical values could have been encoded as integers.

Passing feature types helps AutoPyTorch interpret them correctly as well as
validates the dataset by checking the dtype of the columns for any incompatibilities.

These changes also help in running the [automlbenchmark](https://openml.github.io/automlbenchmark/).
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I have introduced three tests. One ensures that passing the feat types works as expected and they are reflected in the feat types used in the `TabularFeatureValidator` class. The other two check for the correct errors to be raised. 